### PR TITLE
feat: add static cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,22 @@
+# Cosmic Helix Renderer
+
+Offline, ND-safe canvas study of layered sacred geometry.
+
+## What it draws
+- Vesica grid (interlocking circles) — establishes harmonic field.
+- Tree-of-Life nodes and 22 paths — central scaffold.
+- Fibonacci curve — growth spiral, static.
+- Double-helix lattice — two phase-shifted waves with rungs.
+
+Palette is read from `data/palette.json`; missing file falls back to built-in safe colors.
+No animation, no audio, no network requests.
+
+## Usage
+1. Keep `index.html`, `js/helix-renderer.mjs`, and `data/palette.json` together.
+2. Double‑click `index.html` (no server required).
+3. If the palette file is absent, a notice appears and defaults are used.
+
+## Notes
+- Geometry uses numerology constants: 3, 7, 9, 11, 22, 33, 99, 144.
+- All code is pure ES modules with ASCII-only characters.
+- Designed for calm contrast and no motion (ND-safe).

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,131 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted curves with lattice connectors)
+*/
+
+export function renderHelix(ctx, cfg) {
+  const { width, height, palette, NUM } = cfg;
+  // Background fill ensures high-contrast stage
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+// --- Layer 1: Vesica field -------------------------------------------------
+function drawVesica(ctx, w, h, color, NUM) {
+  /* ND-safe: static grid of overlapping circles (vesica piscis);
+     no animation or flashing. */
+  const r = Math.min(w, h) / NUM.THREE;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  for (let y = r; y < h + r; y += r) {
+    for (let x = r; x < w + r; x += r) {
+      ctx.beginPath();
+      ctx.arc(x - r / 2, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(x + r / 2, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+// --- Layer 2: Tree-of-Life scaffold ----------------------------------------
+function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
+  /* Static sephirot + paths, contrast-aware colors.
+     Coordinates scaled by canvas size; numbers reflect canonical layout. */
+  const nodes = [
+    { x: 0.5, y: 0.1 }, // 1 Kether
+    { x: 0.75, y: 0.2 }, // 2 Chokmah
+    { x: 0.25, y: 0.2 }, // 3 Binah
+    { x: 0.75, y: 0.4 }, // 4 Chesed
+    { x: 0.25, y: 0.4 }, // 5 Geburah
+    { x: 0.5, y: 0.5 }, // 6 Tiphereth
+    { x: 0.75, y: 0.6 }, // 7 Netzach
+    { x: 0.25, y: 0.6 }, // 8 Hod
+    { x: 0.5, y: 0.75 }, // 9 Yesod
+    { x: 0.5, y: 0.9 } // 10 Malkuth
+  ];
+  const paths = [
+    [1,2],[1,3],[1,6],[2,3],[2,4],[2,5],[3,5],[3,4],[4,5],
+    [4,6],[5,6],[4,7],[4,8],[5,7],[5,8],[6,7],[6,8],[6,9],
+    [7,9],[8,9],[7,10],[8,10]
+  ]; // 22 connections
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 2;
+  paths.forEach(p => {
+    const a = nodes[p[0]-1], b = nodes[p[1]-1];
+    ctx.beginPath();
+    ctx.moveTo(a.x * w, a.y * h);
+    ctx.lineTo(b.x * w, b.y * h);
+    ctx.stroke();
+  });
+  ctx.fillStyle = nodeColor;
+  nodes.forEach(n => {
+    ctx.beginPath();
+    ctx.arc(n.x * w, n.y * h, NUM.NINE, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+// --- Layer 3: Fibonacci curve ----------------------------------------------
+function drawFibonacci(ctx, w, h, color, NUM) {
+  /* Log spiral inspired by Fibonacci sequence; static polyline. */
+  const cx = w / 2, cy = h / 2;
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const a = Math.min(w, h) / NUM.ONEFORTYFOUR;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i <= NUM.NINETYNINE; i++) {
+    const t = i / NUM.THREE; // smooth curve, ~33 rotations
+    const r = a * Math.pow(phi, t);
+    const x = cx + r * Math.cos(t);
+    const y = cy + r * Math.sin(t);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+// --- Layer 4: Double-helix lattice -----------------------------------------
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  /* Two phase-shifted sine curves with vertical connectors.
+     Static lattice evokes DNA without motion. */
+  const amp = h / NUM.THREE;
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = colorA;
+  ctx.beginPath();
+  for (let x = 0; x <= w; x += 1) {
+    const y = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  ctx.strokeStyle = colorB;
+  ctx.beginPath();
+  for (let x = 0; x <= w; x += 1) {
+    const y = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE + Math.PI);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  // Lattice connectors every 33px
+  ctx.strokeStyle = colorA;
+  for (let x = 0; x <= w; x += NUM.THIRTYTHREE) {
+    const y1 = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE);
+    const y2 = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add offline Cosmic Helix renderer with ND-safe palette and numerology constants
- implement modular helix renderer for vesica grid, tree-of-life, Fibonacci spiral and double-helix lattice
- document usage and provide sample palette

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc9968b8083289efc7a0c22fe0f06