### PR TITLE
Add static Cosmic Helix renderer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Track heavy originals; publish only web derivatives in /docs/assets
+masters/** filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.psb filter=lfs diff=lfs merge=lfs -text
+*.tif filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.aiff filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.DS_Store
+Thumbs.db
+node_modules/
+__pycache__/
+*.pyc
+dist/
+build/
+.cache/
+*.zip
+*.tif
+*.tiff
+*.psd
+*.psb
+*.wav
+*.aiff
+*.aif

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,15 @@
+# Cosmic Helix Renderer
+
+Static HTML+Canvas renderer for layered sacred geometry. ND-safe and offline-first.
+
+## Layers
+1. Vesica field
+2. Tree-of-Life scaffold
+3. Fibonacci curve
+4. Double-helix lattice
+
+## Usage
+1. Double-click `index.html`.
+2. If `data/palette.json` is missing, the renderer falls back to a safe palette.
+
+No network, build, or runtime dependencies.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,129 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine waves)
+
+  All routines are pure and parameterized; palette and numerology constants
+  arrive via the options object. No motion, no external dependencies.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[2], NUM);
+  drawHelix(ctx, width, height, palette.layers.slice(3), NUM);
+}
+
+function drawVesica(ctx, w, h, color, NUM) {
+  // Vesica grid: calm interlocking circles, ND-safe (no strobe)
+  const r = Math.min(w, h) / NUM.THREE;
+  const step = r;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  for (let i = -1; i <= 1; i++) {
+    for (let j = 0; j <= 1; j++) {
+      const cx = w / 2 + i * step;
+      const cy = h / 2 + j * (step / 2);
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+function drawTree(ctx, w, h, color, NUM) {
+  // Simplified Tree-of-Life: 10 nodes, 22 paths
+  const nodes = [
+    [w / 2, h / NUM.ONEFORTYFOUR * 8],
+    [w / 2, h / NUM.TWENTYTWO * 3],
+    [w / 2 - w / NUM.NINE, h / NUM.TWENTYTWO * 6],
+    [w / 2 + w / NUM.NINE, h / NUM.TWENTYTWO * 6],
+    [w / 2 - w / NUM.NINE, h / NUM.TWENTYTWO * 9],
+    [w / 2 + w / NUM.NINE, h / NUM.TWENTYTWO * 9],
+    [w / 2, h / NUM.TWENTYTWO * 12],
+    [w / 2 - w / NUM.THREE, h / NUM.TWENTYTWO * 15],
+    [w / 2 + w / NUM.THREE, h / NUM.TWENTYTWO * 15],
+    [w / 2, h / NUM.TWENTYTWO * 18]
+  ];
+
+  const edges = [
+    [0,1],[0,2],[0,6],
+    [1,2],[1,3],[1,4],
+    [2,3],[2,4],[2,5],
+    [3,4],[3,6],[3,7],
+    [4,5],[4,7],[4,8],
+    [5,6],[5,8],[5,9],
+    [6,7],[6,9],[7,8],[8,9]
+  ];
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  edges.forEach(([a,b]) => {
+    ctx.beginPath();
+    ctx.moveTo(nodes[a][0], nodes[a][1]);
+    ctx.lineTo(nodes[b][0], nodes[b][1]);
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = color;
+  nodes.forEach(([x,y]) => {
+    ctx.beginPath();
+    ctx.arc(x, y, w / NUM.ONEFORTYFOUR * 2, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawFibonacci(ctx, w, h, color, NUM) {
+  // Fibonacci spiral polyline: static, no animation
+  const phi = (1 + Math.sqrt(5)) / 2;
+  let radius = w / NUM.NINETYNINE;
+  let angle = 0;
+  const center = [w / 2, h / 2];
+  const pts = [];
+  for (let i = 0; i < NUM.ELEVEN; i++) {
+    const x = center[0] + radius * Math.cos(angle);
+    const y = center[1] + radius * Math.sin(angle);
+    pts.push([x, y]);
+    radius *= phi;
+    angle += Math.PI / 2;
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+  ctx.stroke();
+}
+
+function drawHelix(ctx, w, h, colors, NUM) {
+  // Double helix lattice: two sine waves, phase-shifted, static
+  const midY = h / 2;
+  const amp = h / NUM.SEVEN; // gentle amplitude
+  const freq = NUM.NINE; // cycles across width
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = colors[0];
+  ctx.beginPath();
+  for (let x = 0; x <= w; x++) {
+    const y = midY + amp * Math.sin((x / w) * freq * Math.PI * 2);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = colors[1];
+  ctx.beginPath();
+  for (let x = 0; x <= w; x++) {
+    const y = midY + amp * Math.sin((x / w) * freq * Math.PI * 2 + Math.PI);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+


### PR DESCRIPTION
## Summary
- Add offline `index.html` with palette fallback and numerology constants for geometry routines
- Implement `helix-renderer.mjs` to draw Vesica grid, Tree-of-Life scaffold, Fibonacci spiral, and double-helix lattice
- Include ND-safe palette JSON and usage documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc97173dc8328afef6d7dc7924cd6