### PR TITLE
Add static cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,23 @@
+# Cosmic Helix Renderer
+
+Static, offline HTML + Canvas module that draws layered sacred geometry.
+
+## Files
+- `index.html` – entry point; open directly in a browser.
+- `js/helix-renderer.mjs` – ES module with pure draw functions.
+- `data/palette.json` – optional palette override; delete to use defaults.
+
+## Usage
+1. Double-click `index.html` (no server needed).
+2. A 1440x900 canvas renders four layers:
+   - Vesica field
+   - Tree-of-Life nodes and paths
+   - Fibonacci curve
+   - Static double-helix lattice
+3. If `data/palette.json` is missing, a fallback palette is used and a note appears.
+
+## ND-Safe Notes
+- No motion, autoplay, or external requests.
+- Soft contrast palette with readable text.
+- Geometry uses numerology constants (3,7,9,11,22,33,99,144) for proportions.
+- Code is plain ES modules; no build tools or dependencies.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg":"#0b0b12",
+  "ink":"#e8e8f0",
+  "layers":["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,133 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands)
+
+  All routines are pure and parameterized. No motion or network calls.
+*/
+
+const TAU = Math.PI * 2;
+
+export function renderHelix(ctx, opts){
+  if (!ctx) return;
+  const { width, height, palette, NUM } = opts;
+  // clear background
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0,0,width,height);
+
+  drawVesica(ctx, { width, height, color: palette.layers[0], NUM });
+  drawTree(ctx, { width, height, colors: [palette.layers[1], palette.layers[2]], NUM });
+  drawFibonacci(ctx, { width, height, color: palette.layers[3], NUM });
+  drawHelix(ctx, { width, height, colors: [palette.layers[4], palette.layers[5]], NUM });
+}
+
+function drawVesica(ctx,{width,height,color,NUM}){
+  // ND-safe: simple strokes, no fill, centered geometry
+  const r = Math.min(width,height)/NUM.THREE;
+  const cx1 = width/2 - r/2;
+  const cx2 = width/2 + r/2;
+  const cy = height/2;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = color;
+  ctx.beginPath();
+  ctx.arc(cx1,cy,r,0,TAU);
+  ctx.arc(cx2,cy,r,0,TAU);
+  ctx.stroke();
+}
+
+function drawTree(ctx,{width,height,colors,NUM}){
+  // layout using percentages; ensures offline determinism
+  const nodes = [
+    [0.5,0.05], // Keter
+    [0.75,0.2], [0.25,0.2], // Chokmah, Binah
+    [0.75,0.4], [0.25,0.4], // Chesed, Geburah
+    [0.5,0.5], // Tiphereth
+    [0.75,0.7], [0.25,0.7], // Netzach, Hod
+    [0.5,0.8], // Yesod
+    [0.5,0.95] // Malkuth
+  ];
+  const paths = [
+    [0,1],[0,2],[1,3],[2,4],[3,5],[4,5],[1,4],[2,3],
+    [5,6],[5,7],[3,6],[4,7],[6,8],[7,8],[8,9],[1,6],
+    [2,7],[0,5],[3,8],[4,8],[1,5],[2,5]
+  ];
+  // draw paths first
+  ctx.strokeStyle = colors[0];
+  ctx.lineWidth = 1;
+  for (const [a,b] of paths){
+    ctx.beginPath();
+    const ax = nodes[a][0]*width; const ay = nodes[a][1]*height;
+    const bx = nodes[b][0]*width; const by = nodes[b][1]*height;
+    ctx.moveTo(ax,ay);
+    ctx.lineTo(bx,by);
+    ctx.stroke();
+  }
+  // draw nodes
+  ctx.fillStyle = colors[1];
+  const rad = Math.min(width,height)/NUM.NINETYNINE * NUM.THREE; // small constant size
+  for (const [x,y] of nodes){
+    ctx.beginPath();
+    ctx.arc(x*width,y*height,rad,0,TAU);
+    ctx.fill();
+  }
+}
+
+function drawFibonacci(ctx,{width,height,color,NUM}){
+  // log spiral using 99 sample points; static polyline
+  const points = [];
+  const a = Math.min(width,height)/NUM.ONEFORTYFOUR;
+  const b = Math.log(1.61803398875);
+  for (let i=0;i<=NUM.NINETYNINE;i++){
+    const t = i/NUM.NINETYNINE * NUM.THREETHREE * Math.PI/NUM.ELEVEN;
+    const r = a * Math.exp(b*t);
+    const x = width/2 + r*Math.cos(t);
+    const y = height/2 + r*Math.sin(t);
+    points.push([x,y]);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(points[0][0], points[0][1]);
+  for (const [x,y] of points.slice(1)){
+    ctx.lineTo(x,y);
+  }
+  ctx.stroke();
+}
+
+function drawHelix(ctx,{width,height,colors,NUM}){
+  // static double helix lattice with 99 horizontal steps
+  const steps = NUM.NINETYNINE;
+  const amp = height/NUM.NINE;
+  const mid = height/2;
+  const freq = NUM.TWENTYTWO;
+  // strands
+  for (let s=0;s<2;s++){
+    ctx.strokeStyle = colors[s];
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    for (let i=0;i<=steps;i++){
+      const x = i/steps * width;
+      const y = mid + amp*Math.sin((i/steps)*freq + s*Math.PI);
+      i===0 ? ctx.moveTo(x,y) : ctx.lineTo(x,y);
+    }
+    ctx.stroke();
+  }
+  // vertical connectors every 11 steps
+  ctx.strokeStyle = colors[1];
+  ctx.lineWidth = 1;
+  for (let i=0;i<=NUM.ELEVEN;i++){
+    const x = i/NUM.ELEVEN * width;
+    const y1 = mid + amp*Math.sin((i/steps)*freq);
+    const y2 = mid + amp*Math.sin((i/steps)*freq + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x,y1);
+    ctx.lineTo(x,y2);
+    ctx.stroke();
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add offline `index.html` that loads a local palette and invokes the helix renderer
- Implement `helix-renderer.mjs` with Vesica field, Tree-of-Life scaffold, Fibonacci spiral, and double-helix lattice
- Include ND-safe color palette JSON and README with usage notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcaee34f88328877cc742f2b68743