### PR TITLE
refactor: finalize cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,6 +1,5 @@
 # Cosmic Helix Renderer
 
-
 Offline, ND-safe canvas study of layered sacred geometry.
 
 ## What it draws
@@ -14,29 +13,8 @@ No animation, no audio, no network requests.
 
 ## Usage
 1. Keep `index.html`, `js/helix-renderer.mjs`, and `data/palette.json` together.
-2. Double‑click `index.html` (no server required).
+2. Double-click `index.html` (no server required).
 3. If the palette file is absent, a notice appears and defaults are used.
-
-## Notes
-- Geometry uses numerology constants: 3, 7, 9, 11, 22, 33, 99, 144.
-- All code is pure ES modules with ASCII-only characters.
-- Designed for calm contrast and no motion (ND-safe).
-=======
-Static, offline HTML + Canvas module that draws layered sacred geometry.
-
-## Files
-- `index.html` – entry point; open directly in a browser.
-- `js/helix-renderer.mjs` – ES module with pure draw functions.
-- `data/palette.json` – optional palette override; delete to use defaults.
-
-## Usage
-1. Double-click `index.html` (no server needed).
-2. A 1440x900 canvas renders four layers:
-   - Vesica field
-   - Tree-of-Life nodes and paths
-   - Fibonacci curve
-   - Static double-helix lattice
-3. If `data/palette.json` is missing, a fallback palette is used and a note appears.
 
 ## ND-Safe Notes
 - No motion, autoplay, or external requests.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,8 +1,5 @@
 {
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
-  "layers": ["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-  "bg":"#0b0b12",
-  "ink":"#e8e8f0",
-  "layers":["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,113 +1,22 @@
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
-
   Layers:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
-    3) Fibonacci curve (log spiral polyline; static)
-
-    4) Double-helix lattice (two phase-shifted curves with lattice connectors)
-*/
-
-export function renderHelix(ctx, cfg) {
-  const { width, height, palette, NUM } = cfg;
-  // Background fill ensures high-contrast stage
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
-}
-
-// --- Layer 1: Vesica field -------------------------------------------------
-function drawVesica(ctx, w, h, color, NUM) {
-  /* ND-safe: static grid of overlapping circles (vesica piscis);
-     no animation or flashing. */
-  const r = Math.min(w, h) / NUM.THREE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h + r; y += r) {
-    for (let x = r; x < w + r; x += r) {
-      ctx.beginPath();
-      ctx.arc(x - r / 2, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + r / 2, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-  }
-}
-
-// --- Layer 2: Tree-of-Life scaffold ----------------------------------------
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  /* Static sephirot + paths, contrast-aware colors.
-     Coordinates scaled by canvas size; numbers reflect canonical layout. */
-  const nodes = [
-    { x: 0.5, y: 0.1 }, // 1 Kether
-    { x: 0.75, y: 0.2 }, // 2 Chokmah
-    { x: 0.25, y: 0.2 }, // 3 Binah
-    { x: 0.75, y: 0.4 }, // 4 Chesed
-    { x: 0.25, y: 0.4 }, // 5 Geburah
-    { x: 0.5, y: 0.5 }, // 6 Tiphereth
-    { x: 0.75, y: 0.6 }, // 7 Netzach
-    { x: 0.25, y: 0.6 }, // 8 Hod
-    { x: 0.5, y: 0.75 }, // 9 Yesod
-    { x: 0.5, y: 0.9 } // 10 Malkuth
-  ];
-  const paths = [
-    [1,2],[1,3],[1,6],[2,3],[2,4],[2,5],[3,5],[3,4],[4,5],
-    [4,6],[5,6],[4,7],[4,8],[5,7],[5,8],[6,7],[6,8],[6,9],
-    [7,9],[8,9],[7,10],[8,10]
-  ]; // 22 connections
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 2;
-  paths.forEach(p => {
-    const a = nodes[p[0]-1], b = nodes[p[1]-1];
-    ctx.beginPath();
-    ctx.moveTo(a.x * w, a.y * h);
-    ctx.lineTo(b.x * w, b.y * h);
-    ctx.stroke();
-  });
-  ctx.fillStyle = nodeColor;
-  nodes.forEach(n => {
-    ctx.beginPath();
-    ctx.arc(n.x * w, n.y * h, NUM.NINE, 0, Math.PI * 2);
-    ctx.fill();
-  });
-}
-
-// --- Layer 3: Fibonacci curve ----------------------------------------------
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Log spiral inspired by Fibonacci sequence; static polyline. */
-  const cx = w / 2, cy = h / 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const a = Math.min(w, h) / NUM.ONEFORTYFOUR;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  for (let i = 0; i <= NUM.NINETYNINE; i++) {
-    const t = i / NUM.THREE; // smooth curve, ~33 rotations
-    const r = a * Math.pow(phi, t);
-    const x = cx + r * Math.cos(t);
-    const y = cy + r * Math.sin(t);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-
+    2) Tree-of-Life scaffold (10 nodes + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
     4) Double-helix lattice (two phase-shifted strands)
-
-  All routines are pure and parameterized. No motion or network calls.
+  All routines are pure, static, and offline.
 */
 
 const TAU = Math.PI * 2;
 
-export function renderHelix(ctx, opts){
+export function renderHelix(ctx, opts) {
   if (!ctx) return;
   const { width, height, palette, NUM } = opts;
-  // clear background
+  // Calm background to reduce visual load.
   ctx.fillStyle = palette.bg;
-  ctx.fillRect(0,0,width,height);
+  ctx.fillRect(0, 0, width, height);
 
   drawVesica(ctx, { width, height, color: palette.layers[0], NUM });
   drawTree(ctx, { width, height, colors: [palette.layers[1], palette.layers[2]], NUM });
@@ -115,140 +24,114 @@ export function renderHelix(ctx, opts){
   drawHelix(ctx, { width, height, colors: [palette.layers[4], palette.layers[5]], NUM });
 }
 
-function drawVesica(ctx,{width,height,color,NUM}){
-  // ND-safe: simple strokes, no fill, centered geometry
-  const r = Math.min(width,height)/NUM.THREE;
-  const cx1 = width/2 - r/2;
-  const cx2 = width/2 + r/2;
-  const cy = height/2;
-  ctx.lineWidth = 2;
+// --- Layer 1: Vesica field ---------------------------------------------------
+function drawVesica(ctx, { width, height, color, NUM }) {
+  /* ND-safe: static grid of overlapping circles; no motion or fill flashes. */
+  const r = Math.min(width, height) / NUM.THREE;
   ctx.strokeStyle = color;
-  ctx.beginPath();
-  ctx.arc(cx1,cy,r,0,TAU);
-  ctx.arc(cx2,cy,r,0,TAU);
-  ctx.stroke();
+  ctx.lineWidth = 1;
+  for (let y = r; y < height + r; y += r) {
+    for (let x = r; x < width + r; x += r) {
+      ctx.beginPath();
+      ctx.arc(x - r / 2, y, r, 0, TAU);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(x + r / 2, y, r, 0, TAU);
+      ctx.stroke();
+    }
+  }
 }
 
-function drawTree(ctx,{width,height,colors,NUM}){
-  // layout using percentages; ensures offline determinism
+// --- Layer 2: Tree-of-Life scaffold ------------------------------------------
+function drawTree(ctx, { width, height, colors, NUM }) {
+  /* ND-safe: simple nodes and paths with readable contrast. */
   const nodes = [
-    [0.5,0.05], // Keter
-    [0.75,0.2], [0.25,0.2], // Chokmah, Binah
-    [0.75,0.4], [0.25,0.4], // Chesed, Geburah
-    [0.5,0.5], // Tiphereth
-    [0.75,0.7], [0.25,0.7], // Netzach, Hod
-    [0.5,0.8], // Yesod
-    [0.5,0.95] // Malkuth
+    [0.5, 0.1],   // 1 Kether
+    [0.75, 0.2],  [0.25, 0.2],  // 2 Chokmah, 3 Binah
+    [0.75, 0.4],  [0.25, 0.4],  // 4 Chesed, 5 Geburah
+    [0.5, 0.5],   // 6 Tiphereth
+    [0.75, 0.6],  [0.25, 0.6],  // 7 Netzach, 8 Hod
+    [0.5, 0.75],  // 9 Yesod
+    [0.5, 0.9]    //10 Malkuth
   ];
   const paths = [
-    [0,1],[0,2],[1,3],[2,4],[3,5],[4,5],[1,4],[2,3],
-    [5,6],[5,7],[3,6],[4,7],[6,8],[7,8],[8,9],[1,6],
-    [2,7],[0,5],[3,8],[4,8],[1,5],[2,5]
-  ];
+    [0,1],[0,2],[0,5],
+    [1,2],[1,3],[1,4],
+    [2,4],[2,5],[3,4],
+    [3,5],[4,5],[3,6],[3,7],
+    [4,6],[4,7],[5,6],[5,7],[5,8],
+    [6,8],[7,8],[6,9],[7,9]
+  ]; // 22 connections
   // draw paths first
   ctx.strokeStyle = colors[0];
   ctx.lineWidth = 1;
-  for (const [a,b] of paths){
+  for (const [a,b] of paths) {
+    const ax = nodes[a][0] * width, ay = nodes[a][1] * height;
+    const bx = nodes[b][0] * width, by = nodes[b][1] * height;
     ctx.beginPath();
-    const ax = nodes[a][0]*width; const ay = nodes[a][1]*height;
-    const bx = nodes[b][0]*width; const by = nodes[b][1]*height;
-    ctx.moveTo(ax,ay);
-    ctx.lineTo(bx,by);
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
     ctx.stroke();
   }
   // draw nodes
   ctx.fillStyle = colors[1];
-  const rad = Math.min(width,height)/NUM.NINETYNINE * NUM.THREE; // small constant size
-  for (const [x,y] of nodes){
+  const rad = Math.min(width, height) / NUM.NINETYNINE * NUM.THREE;
+  for (const [x,y] of nodes) {
     ctx.beginPath();
-    ctx.arc(x*width,y*height,rad,0,TAU);
+    ctx.arc(x * width, y * height, rad, 0, TAU);
     ctx.fill();
   }
 }
 
-function drawFibonacci(ctx,{width,height,color,NUM}){
-  // log spiral using 99 sample points; static polyline
-  const points = [];
-  const a = Math.min(width,height)/NUM.ONEFORTYFOUR;
-  const b = Math.log(1.61803398875);
-  for (let i=0;i<=NUM.NINETYNINE;i++){
-    const t = i/NUM.NINETYNINE * NUM.THREETHREE * Math.PI/NUM.ELEVEN;
-    const r = a * Math.exp(b*t);
-    const x = width/2 + r*Math.cos(t);
-    const y = height/2 + r*Math.sin(t);
-    points.push([x,y]);
-  }
+// --- Layer 3: Fibonacci curve -------------------------------------------------
+function drawFibonacci(ctx, { width, height, color, NUM }) {
+  /* ND-safe: static logarithmic spiral built from 99 points. */
+  const cx = width / 2;
+  const cy = height / 2;
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const a = Math.min(width, height) / NUM.ONEFORTYFOUR;
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.moveTo(points[0][0], points[0][1]);
-  for (const [x,y] of points.slice(1)){
-    ctx.lineTo(x,y);
-
+  for (let i = 0; i <= NUM.NINETYNINE; i++) {
+    const t = i / NUM.THIRTYTHREE; // uses 33 for gentle growth
+    const r = a * Math.pow(phi, t);
+    const x = cx + r * Math.cos(t);
+    const y = cy + r * Math.sin(t);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
 }
 
-
-// --- Layer 4: Double-helix lattice -----------------------------------------
-function drawHelix(ctx, w, h, colorA, colorB, NUM) {
-  /* Two phase-shifted sine curves with vertical connectors.
-     Static lattice evokes DNA without motion. */
-  const amp = h / NUM.THREE;
-  ctx.lineWidth = 1;
-  ctx.strokeStyle = colorA;
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += 1) {
-    const y = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE);
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  ctx.strokeStyle = colorB;
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += 1) {
-    const y = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE + Math.PI);
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  // Lattice connectors every 33px
-  ctx.strokeStyle = colorA;
-  for (let x = 0; x <= w; x += NUM.THIRTYTHREE) {
-    const y1 = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE);
-    const y2 = h/2 + amp * Math.sin((2 * Math.PI * x) / NUM.NINETYNINE + Math.PI);
-    ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
-
-function drawHelix(ctx,{width,height,colors,NUM}){
-  // static double helix lattice with 99 horizontal steps
+// --- Layer 4: Double-helix lattice -------------------------------------------
+function drawHelix(ctx, { width, height, colors, NUM }) {
+  /* ND-safe: static double helix; evokes DNA without motion. */
   const steps = NUM.NINETYNINE;
-  const amp = height/NUM.NINE;
-  const mid = height/2;
+  const amp = height / NUM.SEVEN;
+  const mid = height / 2;
   const freq = NUM.TWENTYTWO;
   // strands
-  for (let s=0;s<2;s++){
+  for (let s = 0; s < 2; s++) {
     ctx.strokeStyle = colors[s];
     ctx.lineWidth = 2;
     ctx.beginPath();
-    for (let i=0;i<=steps;i++){
-      const x = i/steps * width;
-      const y = mid + amp*Math.sin((i/steps)*freq + s*Math.PI);
-      i===0 ? ctx.moveTo(x,y) : ctx.lineTo(x,y);
+    for (let i = 0; i <= steps; i++) {
+      const x = (i / steps) * width;
+      const y = mid + amp * Math.sin((i / steps) * freq + s * Math.PI);
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
   }
   // vertical connectors every 11 steps
-  ctx.strokeStyle = colors[1];
+  ctx.strokeStyle = colors[0];
   ctx.lineWidth = 1;
-  for (let i=0;i<=NUM.ELEVEN;i++){
-    const x = i/NUM.ELEVEN * width;
-    const y1 = mid + amp*Math.sin((i/steps)*freq);
-    const y2 = mid + amp*Math.sin((i/steps)*freq + Math.PI);
+  for (let i = 0; i <= steps; i += NUM.ELEVEN) {
+    const x = (i / steps) * width;
+    const y1 = mid + amp * Math.sin((i / steps) * freq);
+    const y2 = mid + amp * Math.sin((i / steps) * freq + Math.PI);
     ctx.beginPath();
-    ctx.moveTo(x,y1);
-    ctx.lineTo(x,y2);
-
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
     ctx.stroke();
   }
 }
-


### PR DESCRIPTION
## Summary
- Clean up palette and renderer docs for ND-safe offline canvas
- Implement pure helix rendering module with vesica, tree, Fibonacci, and helix layers
- Provide stable palette defaults and static numerology constants

## Testing
- `node -e "import('./js/helix-renderer.mjs').then(m=>console.log(Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc9f780c8328bb19667a292aadfd