### PR TITLE
Document Golden Ratio in Fibonacci spiral and add renderer tests

### DIFF
--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -88,7 +88,7 @@ function drawFibonacci(ctx, { width, height, color, NUM }) {
   /* ND-safe: static logarithmic spiral built from 99 points. */
   const cx = width / 2;
   const cy = height / 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
+  const phi = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps the spiral in sacred proportion
   const a = Math.min(width, height) / NUM.ONEFORTYFOUR;
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+
+def read_text(path):
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_palette_structure():
+    data = json.loads(read_text("data/palette.json"))
+    assert set(data.keys()) == {"bg", "ink", "layers"}
+    assert len(data["layers"]) == 6
+    assert all(color.startswith("#") for color in [data["bg"], data["ink"], *data["layers"]])
+
+
+def test_index_references():
+    txt = read_text("index.html")
+    assert 'js/helix-renderer.mjs' in txt
+    assert 'canvas id="stage"' in txt
+    assert 'width="1440"' in txt and 'height="900"' in txt
+
+
+def test_js_functions_present():
+    txt = read_text("js/helix-renderer.mjs")
+    for name in ["drawVesica", "drawTree", "drawFibonacci", "drawHelix"]:
+        assert f"function {name}" in txt
+
+
+def test_numerology_constants_defined():
+    txt = read_text("index.html")
+    for constant in ["THREE", "SEVEN", "NINE", "ELEVEN", "TWENTYTWO", "THIRTYTHREE", "NINETYNINE", "ONEFORTYFOUR"]:
+        assert constant in txt
+
+
+def test_golden_ratio_comment_present():
+    txt = read_text("js/helix-renderer.mjs")
+    assert "Golden Ratio" in txt


### PR DESCRIPTION
## Summary
- clarify Fibonacci spiral math with Golden Ratio comment
- add comprehensive renderer tests for palette, index markup, numerology constants, and Golden Ratio reference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc165d0c0883289cf4269c00c5dbe7