### PR TITLE
feat: add codex validator and API

### DIFF
--- a/api/README_API.md
+++ b/api/README_API.md
@@ -1,0 +1,6 @@
+# Codex 144:99 — Read-Only API
+
+## Run
+```bash
+uvicorn api.codex_api:app --reload --port 8777
+```

--- a/api/codex_api.py
+++ b/api/codex_api.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Minimal Read-Only API (FastAPI)
+- Serves expanded nodes (data/codex_nodes_full.json)
+- Simple filters: by id, element, planet, zodiac, safety, tags, culture.
+- CORS open by default for local prototypes.
+
+Run:
+  uvicorn api.codex_api:app --reload --port 8777
+"""
+
+import os, json
+from typing import List, Optional
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+DATA_PATH = os.path.join("data","codex_nodes_full.json")
+
+app = FastAPI(title="Codex 144:99 – Read-Only API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"], allow_credentials=False,
+    allow_methods=["GET"], allow_headers=["*"]
+)
+
+def _load():
+    if not os.path.exists(DATA_PATH):
+        raise FileNotFoundError(f"Missing {DATA_PATH}. Build the codex first.")
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.get("/nodes")
+def list_nodes(
+    element: Optional[str] = None,
+    planet: Optional[str] = None,
+    zodiac: Optional[str] = None,
+    safety: Optional[str] = Query(None, description='ptsd_true | with_care'),
+    tag: Optional[str] = Query(None, description='match a fusion tag'),
+    culture: Optional[str] = Query(None, description='match in gods/goddesses culture'),
+    limit: int = 144,
+    offset: int = 0,
+):
+    nodes = _load()
+
+    def match(n):
+        if element and element not in (n.get("element") if isinstance(n.get("element"), str) else " / ".join(n.get("element",[]))):
+            return False
+        if planet and planet not in (n.get("planet") if isinstance(n.get("planet"), str) else " / ".join(n.get("planet",[]))):
+            return False
+        if zodiac and zodiac not in n.get("zodiac",""):
+            return False
+        if tag and tag not in n.get("fusion_tags",[]):
+            return False
+        if safety:
+            s = n.get("healing_profile",{}).get("ptsd_safe")
+            if safety == "ptsd_true" and s is not True: return False
+            if safety == "with_care" and s != "with care": return False
+        if culture:
+            gg = (n.get("gods",[]) or []) + (n.get("goddesses",[]) or [])
+            if not any(culture == g.get("culture") for g in gg):
+                return False
+        return True
+
+    out = [n for n in nodes if match(n)]
+    return {"count": len(out), "items": out[offset:offset+limit]}
+
+@app.get("/nodes/{node_id}")
+def get_node(node_id: int):
+    nodes = _load()
+    for n in nodes:
+        if n.get("node_id") == node_id:
+            return n
+    raise HTTPException(status_code=404, detail="Node not found")

--- a/scripts/validate_codex.py
+++ b/scripts/validate_codex.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Codex 144:99 – Integrity Validator
+- Verifies that expanded nodes in data/codex_nodes_full.json match their lock_hash.
+- Also offers a quick consistency check on required fields.
+
+Run:
+  python scripts/validate_codex.py
+"""
+
+import json, os, sys, hashlib
+
+REQUIRED_TOP = [
+    "node_id","name","locked","egregore_id","shem_angel","goetic_demon",
+    "gods","goddesses","chakra","planet","zodiac","element","platonic_solid",
+    "geometry","art_style","function","ritual_use","fusion_tags",
+    "solfeggio_freq","music_profile","color_scheme","healing_profile","symbolic_keywords"
+]
+
+EXPANDED_PATH = os.path.join("data","codex_nodes_full.json")
+
+def compute_lock_hash(node_no_hash: dict) -> str:
+    """Recreate lock hash exactly like build_codex.py (sort_keys=True, UTF-8)."""
+    payload = json.dumps(node_no_hash, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+def main():
+    if not os.path.exists(EXPANDED_PATH):
+        print(f"[ERROR] Missing {EXPANDED_PATH}. Run scripts/build_codex.py first.", file=sys.stderr)
+        sys.exit(2)
+
+    with open(EXPANDED_PATH,"r",encoding="utf-8") as f:
+        nodes = json.load(f)
+
+    ok = True
+    seen_ids = set()
+    for n in nodes:
+        # basic structural checks
+        for key in REQUIRED_TOP:
+            if key not in n:
+                ok = False
+                print(f"[FAIL] node {n.get('node_id','?')}: missing key '{key}'")
+
+        nid = n.get("node_id")
+        if nid in seen_ids:
+            ok = False
+            print(f"[FAIL] duplicate node_id {nid}")
+        seen_ids.add(nid)
+
+        if not n.get("locked", False):
+            ok = False
+            print(f"[FAIL] node {nid}: locked flag must be True")
+
+        # lock_hash validation
+        lock_hash = n.get("lock_hash")
+        if not lock_hash:
+            ok = False
+            print(f"[FAIL] node {nid}: missing lock_hash")
+        else:
+            n_copy = dict(n)
+            n_copy.pop("lock_hash", None)
+            calc = compute_lock_hash(n_copy)
+            if calc != lock_hash:
+                ok = False
+                print(f"[FAIL] node {nid}: lock_hash mismatch (calc {calc[:12]}..., file {lock_hash[:12]}...)")
+
+    if ok:
+        print(f"[OK] {len(nodes)} nodes validated. All lock_hash values match and structure is sane.")
+        sys.exit(0)
+    else:
+        print("[ERROR] Validation failed. See messages above.", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add integrity validator for codex node data
- expose FastAPI read-only API with filtering and health endpoint

## Testing
- `python scripts/validate_codex.py` (fails: Missing data/codex_nodes_full.json)
- `python -m py_compile scripts/validate_codex.py api/codex_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc1e2a91c08328a06e09d01772a284