### PR TITLE
Add tests for codex validator

### DIFF
--- a/scripts/validate_codex.py
+++ b/scripts/validate_codex.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Codex 144:99 – Integrity Validator
+- Verifies that expanded nodes in data/codex_nodes_full.json match their lock_hash.
+- Also offers a quick consistency check on required fields.
+
+Run:
+  python scripts/validate_codex.py
+"""
+
+import json, os, sys, hashlib
+
+REQUIRED_TOP = [
+    "node_id","name","locked","egregore_id","shem_angel","goetic_demon",
+    "gods","goddesses","chakra","planet","zodiac","element","platonic_solid",
+    "geometry","art_style","function","ritual_use","fusion_tags",
+    "solfeggio_freq","music_profile","color_scheme","healing_profile","symbolic_keywords"
+]
+
+EXPANDED_PATH = os.path.join("data","codex_nodes_full.json")
+
+def compute_lock_hash(node_no_hash: dict) -> str:
+    """Recreate lock hash exactly like build_codex.py (sort_keys=True, UTF-8)."""
+    payload = json.dumps(node_no_hash, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+def main():
+    if not os.path.exists(EXPANDED_PATH):
+        print(f"[ERROR] Missing {EXPANDED_PATH}. Run scripts/build_codex.py first.", file=sys.stderr)
+        sys.exit(2)
+
+    with open(EXPANDED_PATH,"r",encoding="utf-8") as f:
+        nodes = json.load(f)
+
+    ok = True
+    seen_ids = set()
+    for n in nodes:
+        # basic structural checks
+        for key in REQUIRED_TOP:
+            if key not in n:
+                ok = False
+                print(f"[FAIL] node {n.get('node_id','?')}: missing key '{key}'")
+
+        nid = n.get("node_id")
+        if nid in seen_ids:
+            ok = False
+            print(f"[FAIL] duplicate node_id {nid}")
+        seen_ids.add(nid)
+
+        if not n.get("locked", False):
+            ok = False
+            print(f"[FAIL] node {nid}: locked flag must be True")
+
+        # lock_hash validation
+        lock_hash = n.get("lock_hash")
+        if not lock_hash:
+            ok = False
+            print(f"[FAIL] node {nid}: missing lock_hash")
+        else:
+            n_copy = dict(n)
+            n_copy.pop("lock_hash", None)
+            calc = compute_lock_hash(n_copy)
+            if calc != lock_hash:
+                ok = False
+                print(f"[FAIL] node {nid}: lock_hash mismatch (calc {calc[:12]}..., file {lock_hash[:12]}...)")
+
+    if ok:
+        print(f"[OK] {len(nodes)} nodes validated. All lock_hash values match and structure is sane.")
+        sys.exit(0)
+    else:
+        print("[ERROR] Validation failed. See messages above.", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_codex.py
+++ b/tests/test_validate_codex.py
@@ -1,0 +1,85 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+import importlib.util
+
+# Load the validator module without requiring package imports
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_codex.py"
+spec = importlib.util.spec_from_file_location("validate_codex", SCRIPT)
+validate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validate)
+
+
+def _write_nodes(tmp_path, nodes):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    with (data_dir / "codex_nodes_full.json").open("w", encoding="utf-8") as f:
+        json.dump(nodes, f, ensure_ascii=False)
+
+
+def _run_validator(tmp_path):
+    """Execute the script as a standalone process."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _base_node():
+    return {
+        "node_id": 1,
+        "name": "Test",
+        "locked": True,
+        "egregore_id": 1,
+        "shem_angel": "A",
+        "goetic_demon": "B",
+        "gods": [],
+        "goddesses": [],
+        "chakra": "root",
+        "planet": "earth",
+        "zodiac": "aries",
+        "element": "fire",
+        "platonic_solid": "tetrahedron",
+        "geometry": "vesica",
+        "art_style": "minimal",
+        "function": "test",
+        "ritual_use": "none",
+        "fusion_tags": [],
+        "solfeggio_freq": 963,
+        "music_profile": {},
+        "color_scheme": {},
+        "healing_profile": {},
+        "symbolic_keywords": [],
+    }
+
+
+def test_validation_success(tmp_path):
+    node = _base_node()
+    node_copy = dict(node)
+    node["lock_hash"] = validate.compute_lock_hash(node_copy)
+    _write_nodes(tmp_path, [node])
+    res = _run_validator(tmp_path)
+    assert res.returncode == 0
+    assert "[OK] 1 nodes validated" in res.stdout
+
+
+def test_validation_lock_hash_mismatch(tmp_path):
+    node = _base_node()
+    node["lock_hash"] = "bad" * 16
+    _write_nodes(tmp_path, [node])
+    res = _run_validator(tmp_path)
+    assert res.returncode == 1
+    assert "lock_hash mismatch" in res.stdout
+
+
+def test_validation_missing_field(tmp_path):
+    node = _base_node()
+    node.pop("name")
+    node["lock_hash"] = validate.compute_lock_hash(node)
+    _write_nodes(tmp_path, [node])
+    res = _run_validator(tmp_path)
+    assert res.returncode == 1
+    assert "missing key 'name'" in res.stdout


### PR DESCRIPTION
## Summary
- add integrity validator for codex node data
- cover validator with tests for success, bad hashes, and missing fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1e074e948328a4a8a1c0af05b68c