### PR TITLE
Add minimal package.json for npm-based tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "codex-14499",
+  "version": "1.0.0",
+  "description": "Cosmic helix renderer and codex validation scripts",
+  "type": "module",
+  "scripts": {
+    "test": "pytest"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with npm test script to run pytest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcada07aa88328bffefac3d10e6302