### PR TITLE
feat: configurable geometry constants and palette contrast check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,24 @@
+# Codex 144:99 — Repository Map
+
+This repo currently combines:
+
+- **Renderer** (`index.html`, `js/`, `data/`) – static canvas for layered cosmology. Loads palette and geometry from JSON for offline tweaking.
+- **API** (`api/`) – FastAPI service exposing codex nodes from `data/`. Intended for read-only queries by games or tools.
+- **Docs** (`docs/`) – mirror of renderer for documentation or static hosting.
+
+## Connections
+
+- Renderer and docs both read from the shared `data/` folder.
+- API serves an expanded node set (`data/codex_nodes_full.json` when available) for game engines or world-building utilities.
+
+## Toward Multi‑Game, Complex Environments
+
+- Keep JSON schemas stable so multiple engines can consume the same data.
+- Expose additional endpoints in the API for tags, cultures, and safety profiles.
+- Use the geometry and palette configs to theme different game worlds without altering core code.
+
+## Outstanding Integration Tasks
+
+- Expand node dataset to cover additional realms or settings.
+- Define a plugin pattern where individual games contribute their own layers or palettes.
+- Draft examples of using the API + renderer together for a world-building workflow.

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -18,6 +18,10 @@ Static offline canvas renderer for layered sacred geometry.
 
 Colors come from `data/palette.json`. If the file is missing the renderer falls back to a safe default and notes this inline.
 
+## Geometry Constants
+
+Numerology values (3,7,9,11,22,33,99,144) may be tweaked in `data/geometry.json`. Missing file reverts to the default set encoded in `index.html`.
+
 ## ND-safe Design
 
 - No motion or autoplay

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,14 @@
 # Update Tasks
 
-- [ ] Provide contrast ratio verification for palette to ensure ND-safe readability.
-- [ ] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
+## Completed
+
+- [x] Static renderer, palette, and geometry configs load offline.
+- [x] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
+- [x] Provide contrast ratio verification for palette to ensure ND-safe readability.
+
+## Next Steps
+
 - [ ] Document layer math in greater depth in `README_RENDERER.md` to aid future contributors.
 - [ ] Add optional screenshot of rendered canvas to `README_RENDERER.md` for quick preview.
 - [ ] Test renderer across additional browsers to confirm offline fetch behavior and color rendering.
+- [ ] Map how API, renderer, and data can serve multiple games and complex world-building contexts.

--- a/data/geometry.json
+++ b/data/geometry.json
@@ -1,0 +1,10 @@
+{
+  "THREE": 3,
+  "SEVEN": 7,
+  "NINE": 9,
+  "ELEVEN": 11,
+  "TWENTYTWO": 22,
+  "THIRTYTHREE": 33,
+  "NINETYNINE": 99,
+  "ONEFORTYFOUR": 144
+}

--- a/docs/README_RENDERER.md
+++ b/docs/README_RENDERER.md
@@ -1,26 +1,29 @@
 # Cosmic Helix Renderer
 
-Offline, ND-safe canvas study of layered sacred geometry.
-
-## What it draws
-- Vesica grid (interlocking circles) - establishes harmonic field.
-- Tree-of-Life nodes and 22 paths - central scaffold.
-- Fibonacci curve - growth spiral, static.
-- Double-helix lattice - two phase-shifted waves with rungs.
-
-Palette is read from `data/palette.json`; missing file falls back to built-in safe colors.
-No animation, no audio, no network requests.
+Static offline canvas renderer for layered sacred geometry.
 
 ## Usage
-1. Keep `index.html`, `js/helix-renderer.mjs`, and `data/palette.json` together.
-2. Double-click `index.html` (no server required).
-3. If the palette file is absent, a notice appears and defaults are used.
 
-## ND-Safe Notes
-- No motion, autoplay, or external requests.
-- Soft contrast palette with readable text.
-- Geometry uses numerology constants (3,7,9,11,22,33,99,144) for proportions.
-- Code is plain ES modules; no build tools or dependencies.
+1. Double-click `index.html` in any modern browser.
+2. The 1440x900 canvas will draw without network access or libraries.
 
-## References
-- W3C Web Accessibility Initiative. "Audio and Video: Accessible Alternatives." 2019. [@w3c_media]
+## Layers
+
+1. Vesica field
+2. Tree-of-Life scaffold
+3. Fibonacci curve
+4. Static double-helix lattice
+
+## Palette
+
+Colors come from `data/palette.json`. If the file is missing the renderer falls back to a safe default and notes this inline.
+
+## Geometry Constants
+
+Numerology values (3,7,9,11,22,33,99,144) may be tweaked in `data/geometry.json`. Missing file reverts to the default set encoded in `index.html`.
+
+## ND-safe Design
+
+- No motion or autoplay
+- Calming contrast and soft colors
+- Pure ES module, no dependencies, no builds

--- a/docs/data/geometry.json
+++ b/docs/data/geometry.json
@@ -1,0 +1,10 @@
+{
+  "THREE": 3,
+  "SEVEN": 7,
+  "NINE": 9,
+  "ELEVEN": 11,
+  "TWENTYTWO": 22,
+  "THIRTYTHREE": 33,
+  "NINETYNINE": 99,
+  "ONEFORTYFOUR": 144
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading resources…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -47,18 +47,20 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      },
+      geometry: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    const geom = await loadJSON("./data/geometry.json");
+    const activePalette = palette || defaults.palette;
+    const NUM = geom || defaults.geometry;
+    elStatus.textContent =
+      (palette ? "Palette loaded. " : "Palette missing; using safe fallback. ") +
+      (geom ? "Geometry loaded." : "Geometry missing; using defaults.");
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:activePalette, NUM });
   </script>
 </body>
 </html>

--- a/docs/js/helix-renderer.mjs
+++ b/docs/js/helix-renderer.mjs
@@ -1,137 +1,132 @@
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
+
   Layers:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 nodes + 22 paths)
-    3) Fibonacci curve (log spiral polyline)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
     4) Double-helix lattice (two phase-shifted strands)
-  All routines are pure, static, and offline.
 */
 
-const TAU = Math.PI * 2;
-
 export function renderHelix(ctx, opts) {
-  if (!ctx) return;
   const { width, height, palette, NUM } = opts;
-  // Calm background to reduce visual load.
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  drawVesica(ctx, { width, height, color: palette.layers[0], NUM });
-  drawTree(ctx, { width, height, colors: [palette.layers[1], palette.layers[2]], NUM });
-  drawFibonacci(ctx, { width, height, color: palette.layers[3], NUM });
-  drawHelix(ctx, { width, height, colors: [palette.layers[4], palette.layers[5]], NUM });
+  drawVesica(ctx, opts);
+  drawTree(ctx, opts);
+  drawFibonacci(ctx, opts);
+  drawHelix(ctx, opts);
 }
 
-// --- Layer 1: Vesica field ---------------------------------------------------
-function drawVesica(ctx, { width, height, color, NUM }) {
-  /* ND-safe: static grid of overlapping circles; no motion or fill flashes. */
-  const r = Math.min(width, height) / NUM.THREE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < height + r; y += r) {
-    for (let x = r; x < width + r; x += r) {
-      ctx.beginPath();
-      ctx.arc(x - r / 2, y, r, 0, TAU);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + r / 2, y, r, 0, TAU);
-      ctx.stroke();
-    }
-  }
-}
+// Layer 1: Vesica field
+// ND-safe: static intersecting circles, soft lines
+function drawVesica(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  ctx.strokeStyle = palette.layers[0];
+  const radius = Math.min(width, height) / NUM.THREE;
+  const offset = radius / NUM.NINE;
+  const centerY = height / 2;
 
-// --- Layer 2: Tree-of-Life scaffold ------------------------------------------
-function drawTree(ctx, { width, height, colors, NUM }) {
-  /* ND-safe: simple nodes and paths with readable contrast. */
-  const nodes = [
-    [0.5, 0.1],   // 1 Kether
-    [0.75, 0.2],  [0.25, 0.2],  // 2 Chokmah, 3 Binah
-    [0.75, 0.4],  [0.25, 0.4],  // 4 Chesed, 5 Geburah
-    [0.5, 0.5],   // 6 Tiphereth
-    [0.75, 0.6],  [0.25, 0.6],  // 7 Netzach, 8 Hod
-    [0.5, 0.75],  // 9 Yesod
-    [0.5, 0.9]    //10 Malkuth
-  ];
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,3],[1,4],
-    [2,4],[2,5],[3,4],
-    [3,5],[4,5],[3,6],[3,7],
-    [4,6],[4,7],[5,6],[5,7],[5,8],
-    [6,8],[7,8],[6,9],[7,9]
-  ]; // 22 connections
-  // draw paths first
-  ctx.strokeStyle = colors[0];
-  ctx.lineWidth = 1;
-  for (const [a,b] of paths) {
-    const ax = nodes[a][0] * width, ay = nodes[a][1] * height;
-    const bx = nodes[b][0] * width, by = nodes[b][1] * height;
+  for (let i = -NUM.THREE; i <= NUM.THREE; i++) {
+    const cx = width / 2 + i * offset * NUM.SEVEN;
     ctx.beginPath();
-    ctx.moveTo(ax, ay);
-    ctx.lineTo(bx, by);
+    ctx.arc(cx - radius / NUM.THREE, centerY, radius, 0, Math.PI * 2);
+    ctx.arc(cx + radius / NUM.THREE, centerY, radius, 0, Math.PI * 2);
     ctx.stroke();
   }
-  // draw nodes
-  ctx.fillStyle = colors[1];
-  const rad = Math.min(width, height) / NUM.NINETYNINE * NUM.THREE;
-  for (const [x,y] of nodes) {
-    ctx.beginPath();
-    ctx.arc(x * width, y * height, rad, 0, TAU);
-    ctx.fill();
-  }
+  ctx.restore();
 }
 
-// --- Layer 3: Fibonacci curve -------------------------------------------------
-function drawFibonacci(ctx, { width, height, color, NUM }) {
-  /* ND-safe: static logarithmic spiral built from 99 points. */
+// Layer 2: Tree-of-Life scaffold
+// ND-safe: nodes and paths only, no flashing
+function drawTree(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  ctx.strokeStyle = palette.layers[1];
+  ctx.fillStyle = palette.layers[2];
+  const r = width / NUM.NINETYNINE;
+  const nodes = [
+    [0.5, 0.05],
+    [0.25, 0.2], [0.75, 0.2],
+    [0.25, 0.4], [0.75, 0.4],
+    [0.5, 0.55],
+    [0.25, 0.7], [0.75, 0.7],
+    [0.5, 0.85],
+    [0.5, 0.95]
+  ];
+  const paths = [
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,6],[5,6],[5,7],[6,7],[6,8],[7,8],[8,9]
+  ];
+  ctx.beginPath();
+  paths.forEach(([a,b]) => {
+    const [x1,y1] = nodes[a];
+    const [x2,y2] = nodes[b];
+    ctx.moveTo(x1 * width, y1 * height);
+    ctx.lineTo(x2 * width, y2 * height);
+  });
+  ctx.stroke();
+  nodes.forEach(([nx,ny]) => {
+    ctx.beginPath();
+    ctx.arc(nx * width, ny * height, r, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+// Layer 3: Fibonacci curve
+// ND-safe: single log spiral, uses the Golden Ratio
+function drawFibonacci(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  ctx.strokeStyle = palette.layers[3];
+  ctx.beginPath();
+  const PHI = (1 + Math.sqrt(5)) / 2; // Golden Ratio
+  const steps = NUM.TWENTYTWO;
+  const scale = Math.min(width, height) / NUM.ONEFORTYFOUR;
+  let angle = 0;
+  let radius = scale;
   const cx = width / 2;
   const cy = height / 2;
-  const phi = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps the spiral in sacred proportion
-  const a = Math.min(width, height) / NUM.ONEFORTYFOUR;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  for (let i = 0; i <= NUM.NINETYNINE; i++) {
-    const t = i / NUM.THIRTYTHREE; // uses 33 for gentle growth
-    const r = a * Math.pow(phi, t);
-    const x = cx + r * Math.cos(t);
-    const y = cy + r * Math.sin(t);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  ctx.moveTo(cx, cy);
+  for (let i = 0; i < steps; i++) {
+    const x = cx + radius * Math.cos(angle);
+    const y = cy + radius * Math.sin(angle);
+    ctx.lineTo(x, y);
+    radius *= PHI;
+    angle += Math.PI / NUM.SEVEN;
   }
   ctx.stroke();
+  ctx.restore();
 }
 
-// --- Layer 4: Double-helix lattice -------------------------------------------
-function drawHelix(ctx, { width, height, colors, NUM }) {
-  /* ND-safe: static double helix; evokes DNA without motion. */
+// Layer 4: Double-helix lattice
+// ND-safe: static lattice without oscillation
+function drawHelix(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  ctx.strokeStyle = palette.layers[4];
+  const amplitude = width / NUM.THIRTYTHREE;
   const steps = NUM.NINETYNINE;
-  const amp = height / NUM.SEVEN;
-  const mid = height / 2;
-  const freq = NUM.TWENTYTWO;
-  // strands
-  for (let s = 0; s < 2; s++) {
-    ctx.strokeStyle = colors[s];
-    ctx.lineWidth = 2;
+  const strands = [0, Math.PI];
+  strands.forEach(phase => {
     ctx.beginPath();
     for (let i = 0; i <= steps; i++) {
-      const x = (i / steps) * width;
-      const y = mid + amp * Math.sin((i / steps) * freq + s * Math.PI);
+      const t = i / steps;
+      const x = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + phase);
+      const y = t * height;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
-  }
-  // vertical connectors every 11 steps
-  ctx.strokeStyle = colors[0];
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= steps; i += NUM.ELEVEN) {
-    const x = (i / steps) * width;
-    const y1 = mid + amp * Math.sin((i / steps) * freq);
-    const y2 = mid + amp * Math.sin((i / steps) * freq + Math.PI);
+  });
+  ctx.strokeStyle = palette.layers[5];
+  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
+    const t = i / NUM.THIRTYTHREE;
+    const y = t * height;
+    const x1 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI);
+    const x2 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + Math.PI);
     ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
+    ctx.moveTo(x1, y);
+    ctx.lineTo(x2, y);
     ctx.stroke();
   }
+  ctx.restore();
 }

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div class="status" id="status">Loading resources…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -47,18 +47,20 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      },
+      geometry: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    const geom = await loadJSON("./data/geometry.json");
+    const activePalette = palette || defaults.palette;
+    const NUM = geom || defaults.geometry;
+    elStatus.textContent =
+      (palette ? "Palette loaded. " : "Palette missing; using safe fallback. ") +
+      (geom ? "Geometry loaded." : "Geometry missing; using defaults.");
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:activePalette, NUM });
   </script>
 </body>
 </html>

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -13,11 +13,18 @@ def test_palette_structure():
     assert all(color.startswith("#") for color in [data["bg"], data["ink"], *data["layers"]])
 
 
+def test_geometry_structure():
+    data = json.loads(read_text("data/geometry.json"))
+    keys = {"THREE","SEVEN","NINE","ELEVEN","TWENTYTWO","THIRTYTHREE","NINETYNINE","ONEFORTYFOUR"}
+    assert set(data.keys()) == keys
+
+
 def test_index_references():
     txt = read_text("index.html")
     assert 'js/helix-renderer.mjs' in txt
     assert 'canvas id="stage"' in txt
     assert 'width="1440"' in txt and 'height="900"' in txt
+    assert 'geometry.json' in txt
 
 
 def test_js_functions_present():
@@ -35,3 +42,27 @@ def test_numerology_constants_defined():
 def test_golden_ratio_comment_present():
     txt = read_text("js/helix-renderer.mjs")
     assert "Golden Ratio" in txt
+
+
+def test_palette_contrast():
+    def hex_to_rgb(h):
+        h = h.lstrip('#')
+        return tuple(int(h[i:i+2],16)/255 for i in (0,2,4))
+
+    def luminance(rgb):
+        def adj(c):
+            return c/12.92 if c <= 0.03928 else ((c+0.055)/1.055)**2.4
+        r,g,b = map(adj, rgb)
+        return 0.2126*r + 0.7152*g + 0.0722*b
+
+    def contrast(a,b):
+        l1,l2 = sorted([luminance(hex_to_rgb(a)), luminance(hex_to_rgb(b))])
+        return (l2+0.05)/(l1+0.05)
+
+    data = json.loads(read_text("data/palette.json"))
+    bg = data["bg"]
+    ink = data["ink"]
+    layers = data["layers"]
+    assert contrast(bg, ink) >= 7
+    for layer in layers:
+        assert contrast(bg, layer) >= 7


### PR DESCRIPTION
## Summary
- load geometry numbers from `data/geometry.json` with safe fallback
- verify palette contrast ratios and geometry config in tests
- document repo map and offline config features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc59d59ec83289e60cb4d988774dc