### PR TITLE
chore: add duplicate line cleaner

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -50,3 +50,17 @@ npm test
 ```
 
 This uses Node's script runner to call `pytest -q`, keeping everything local and dependency-free.
+
+## Duplicate Line Cleaner
+
+Accidental double pushes can create duplicate lines. Scan the repo:
+
+```sh
+npm run dedup
+```
+
+Remove duplicates in-place (edit with care):
+
+```sh
+npm run dedup:fix
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "type": "module",
 
   "scripts": {
-    "test": "pytest -q"
+    "test": "pytest -q",
+    "dedup": "python scripts/dedup.py",
+    "dedup:fix": "python scripts/dedup.py --fix"
   }
 }

--- a/scripts/dedup.py
+++ b/scripts/dedup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+dedup.py - scan for consecutive duplicate lines and optionally fix them.
+ND-safe: plain text output, no network, deterministic.
+Use --fix to remove duplicates in-place.
+"""
+
+import sys
+from pathlib import Path
+
+# watch simple text formats only
+TEXT_EXT = {".js", ".mjs", ".html", ".json", ".md", ".py", ".txt"}
+SKIP = {".git", "node_modules", "__pycache__"}
+
+def iter_text_files(root):
+    """Yield text files under root, skipping excluded dirs."""
+    for path in Path(root).rglob("*"):
+        if path.is_file() and path.suffix in TEXT_EXT and not any(part in SKIP for part in path.parts):
+            yield path
+
+def dedup_file(path, fix=False):
+    """Return list of (line_no, text) duplicates; remove if fix."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    new_lines = []
+    dups = []
+    prev = None
+    for no, line in enumerate(lines, 1):
+        if line == prev and line.strip():
+            dups.append((no, line))
+            if not fix:
+                new_lines.append(line)
+        else:
+            new_lines.append(line)
+        prev = line
+    if fix and dups:
+        path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    return dups
+
+def main():
+    fix = "--fix" in sys.argv
+    root = Path(__file__).resolve().parents[1]
+    any_dups = False
+    for file in iter_text_files(root):
+        dups = dedup_file(file, fix)
+        if dups:
+            any_dups = True
+            print(f"{file}:")
+            for no, text in dups:
+                print(f"  dup line {no}: {text}")
+    if not any_dups:
+        print("No duplicate lines found.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+def load():
+    root = Path(__file__).resolve().parents[1]
+    sys.path.append(str(root / 'scripts'))
+    from dedup import dedup_file
+    return dedup_file
+
+def test_dedup_file(tmp_path):
+    dedup_file = load()
+    p = tmp_path / 'sample.txt'
+    p.write_text('a\na\nb\nb\n', encoding='utf-8')
+    dups = dedup_file(p, fix=True)
+    assert dups == [(2, 'a'), (4, 'b')]
+    assert p.read_text(encoding='utf-8') == 'a\nb\n'


### PR DESCRIPTION
## Summary
- add `dedup.py` script to detect and fix consecutive duplicate lines
- expose `dedup` and `dedup:fix` npm scripts
- document duplicate line cleaner and add tests

## Testing
- `npm run dedup`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be02bd39608328a61624e6c7c239e0