### PR TITLE
docs: track helix renderer status and next steps

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,13 @@
-# Update Tasks
+## Working
+
+- [x] Replaced broken helix renderer with a static HTML+Canvas version using layered sacred geometry.
+- [x] Palette loads from `data/palette.json` with a safe fallback if the file is missing.
+
+## To Do
 
 - [ ] Provide contrast ratio verification for palette to ensure ND-safe readability.
 - [ ] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
 - [ ] Document layer math in greater depth in `README_RENDERER.md` to aid future contributors.
 - [ ] Add optional screenshot of rendered canvas to `README_RENDERER.md` for quick preview.
 - [ ] Test renderer across additional browsers to confirm offline fetch behavior and color rendering.
+- [ ] Introduce style toggles to adapt visuals for book, learning, or music modes without breaking ND-safe rules.


### PR DESCRIPTION
## Summary
- document new static HTML+Canvas helix renderer with palette fallback
- add current working features and outstanding tasks in TASKS.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4566bd7483288e30a5ff984513ba