### PR TITLE
feat: allow geometry constants from config

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -28,6 +28,25 @@ Static offline canvas renderer for layered sacred geometry.
 
 Colors come from `data/palette.json`. If the file is missing the renderer falls back to a safe default and notes this inline.
 
+## Geometry Constants
+
+Proportions are derived from numerology values (3,7,9,11,22,33,99,144). To experiment, create `data/constants.json`:
+
+```json
+{
+  "THREE": 3,
+  "SEVEN": 7,
+  "NINE": 9,
+  "ELEVEN": 11,
+  "TWENTYTWO": 22,
+  "THIRTYTHREE": 33,
+  "NINETYNINE": 99,
+  "ONEFORTYFOUR": 144
+}
+```
+
+If absent, defaults are used and a notice appears in the header.
+
 ## ND-safe Design
 
 - No motion, autoplay, or external requests.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,7 @@
 # Update Tasks
 
 - [ ] Provide contrast ratio verification for palette to ensure ND-safe readability.
-- [ ] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
+- [x] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
 - [ ] Document layer math in greater depth in `README_RENDERER.md` to aid future contributors.
 - [ ] Add optional screenshot of rendered canvas to `README_RENDERER.md` for quick preview.
 - [ ] Test renderer across additional browsers to confirm offline fetch behavior and color rendering.

--- a/data/constants.json
+++ b/data/constants.json
@@ -1,0 +1,10 @@
+{
+  "THREE": 3,
+  "SEVEN": 7,
+  "NINE": 9,
+  "ELEVEN": 11,
+  "TWENTYTWO": 22,
+  "THIRTYTHREE": 33,
+  "NINETYNINE": 99,
+  "ONEFORTYFOUR": 144
+}

--- a/index.html
+++ b/index.html
@@ -48,15 +48,22 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      },
+      NUM: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const [palette, constants] = await Promise.all([
+      loadJSON("./data/palette.json"),
+      loadJSON("./data/constants.json")
+    ]);
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    const active = palette || defaults.palette;
+    const NUM = constants || defaults.NUM;
+
+    let msg = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    msg += " ";
+    msg += constants ? "Constants loaded." : "Constants missing; using defaults.";
+    elStatus.textContent = msg.trim();
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });


### PR DESCRIPTION
## Summary
- allow geometry constants to be overridden via `data/constants.json`
- document geometry constant config and mark task as complete

## Testing
- `npm test`
- `npm run rubric` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68be47a4418c8328ab2a6a75326e8d6e