### PR TITLE
feat: configurable constants and contrast check

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -28,6 +28,14 @@ Static offline canvas renderer for layered sacred geometry.
 
 Colors come from `data/palette.json`. If the file is missing the renderer falls back to a safe default and notes this inline.
 
+Numerology constants (3,7,9,11,22,33,99,144) may be tweaked via `data/constants.json`. Delete the file to restore defaults.
+
+To check color contrast ratios against the background, run:
+
+```sh
+npm run contrast
+```
+
 ## ND-safe Design
 
 - No motion, autoplay, or external requests.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,7 @@
 # Update Tasks
 
-- [ ] Provide contrast ratio verification for palette to ensure ND-safe readability.
-- [ ] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
+- [x] Provide contrast ratio verification for palette to ensure ND-safe readability.
+- [x] Allow geometry constants (e.g., 3,7,9,11,22,33,99,144) to be adjusted via a small JSON config for experimentation.
 - [ ] Document layer math in greater depth in `README_RENDERER.md` to aid future contributors.
 - [ ] Add optional screenshot of rendered canvas to `README_RENDERER.md` for quick preview.
 - [ ] Test renderer across additional browsers to confirm offline fetch behavior and color rendering.

--- a/data/constants.json
+++ b/data/constants.json
@@ -1,0 +1,10 @@
+{
+  "THREE": 3,
+  "SEVEN": 7,
+  "NINE": 9,
+  "ELEVEN": 11,
+  "TWENTYTWO": 22,
+  "THIRTYTHREE": 33,
+  "NINETYNINE": 99,
+  "ONEFORTYFOUR": 144
+}

--- a/index.html
+++ b/index.html
@@ -48,15 +48,16 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      },
+      constants: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
     };
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    const constants = await loadJSON("./data/constants.json");
+    const NUM = constants || defaults.constants;
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "pytest -q",
     "dedup": "python scripts/dedup.py",
-    "dedup:fix": "python scripts/dedup.py --fix"
+    "dedup:fix": "python scripts/dedup.py --fix",
+    "contrast": "node scripts/check-contrast.mjs"
   }
 }

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -1,0 +1,36 @@
+import { readFile } from 'fs/promises';
+
+// Small helper: convert hex color to RGB [0,1]
+function hexToRgb(hex) {
+  const n = parseInt(hex.replace('#',''), 16);
+  return [n >> 16 & 255, n >> 8 & 255, n & 255].map(v => v / 255);
+}
+
+// Relative luminance per WCAG
+function luminance([r,g,b]) {
+  const ch = [r,g,b].map(v => {
+    return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055, 2.4);
+  });
+  return 0.2126*ch[0] + 0.7152*ch[1] + 0.0722*ch[2];
+}
+
+function contrast(a, b) {
+  const L1 = luminance(hexToRgb(a));
+  const L2 = luminance(hexToRgb(b));
+  const [bright, dark] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (bright + 0.05) / (dark + 0.05);
+}
+
+async function main() {
+  const url = new URL('../data/palette.json', import.meta.url);
+  const text = await readFile(url, 'utf8');
+  const pal = JSON.parse(text);
+  console.log('Contrast bg vs ink:', contrast(pal.bg, pal.ink).toFixed(2));
+  (pal.layers || []).forEach((color,i) => {
+    console.log(`Contrast bg vs layer ${i+1}:`, contrast(pal.bg, color).toFixed(2));
+  });
+}
+
+main().catch(err => {
+  console.error('Could not read palette:', err.message);
+});


### PR DESCRIPTION
## Summary
- load optional `data/constants.json` to tune numerology values without editing code
- add `scripts/check-contrast.mjs` and `npm run contrast` for palette ratio verification
- document palette constants and contrast check in renderer guide; mark tasks completed

## Testing
- `npm run contrast`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be47f54ad88328a94429938a593da5