### PR TITLE
Refine offline helix loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      } catch (err) {
+      } catch {
         return null;
       }
     }
@@ -49,11 +49,7 @@
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
       },
-
       NUM: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
-
-      constants: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
-
     };
 
     const [palette, constants] = await Promise.all([
@@ -64,15 +60,10 @@
     const active = palette || defaults.palette;
     const NUM = constants || defaults.NUM;
 
-
     let msg = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
     msg += " ";
     msg += constants ? "Constants loaded." : "Constants missing; using defaults.";
     elStatus.textContent = msg.trim();
-
-    const constants = await loadJSON("./data/constants.json");
-    const NUM = constants || defaults.constants;
-
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });


### PR DESCRIPTION
## Summary
- Simplify index script for offline helix renderer
- Load palette and numerology constants with safe fallbacks
- Display inline status message for missing files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be529f1ed4832885d29148f02e6d2c