### PR TITLE
add octagram halls text and tidy renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,10 +1,6 @@
-Per Texturas Numerorum, Spira Loquitur.  //
+Per Texturas Numerorum, Spira Loquitur.
 # Cosmic Helix Renderer
 
-Static offline renderer for the Codex 144:99 geometry helix. Double-click `index.html` to open in any modern browser. No server and no network needed.
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Double-click `index.html` in any modern browser—no server or network calls.
-Static offline renderer for the Codex 144:99 geometry helix. Double-click `index.html` to open in any modern browser.
-No server, no network.
 Static offline canvas renderer for layered sacred geometry in Codex 144:99. Double-click `index.html` in any modern browser—no server or network calls.
 
 ## Files
@@ -26,22 +22,18 @@ Static offline canvas renderer for layered sacred geometry in Codex 144:99. Doub
 
 ## Customization
 - Edit `data/palette.json` to change colors.
-- Optionally add `data/constants.json` with numerology values to tweak proportions.
 
 ## Local Use
 Open `index.html` directly in any modern browser.
-- No motion, autoplay, or external requests.
-- Calming contrast and soft colors.
-- Geometry uses numerology constants 3,7,9,11,22,33,99,144.
 
 ## Tests
 Run local checks:
 
-```sh
+```
 npm test
 ```
+
 ## Notes
 - ND-safe: calm contrast, no motion, optional palette override.
-- All geometry uses constants 3, 7, 9, 11, 22, 33, 99, 144.
 - If `data/palette.json` is missing, a built-in fallback palette renders instead.
-- Works completely offline; open `index.html` directly.
+- Works completely offline.

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
           .filter(line => !line.trim().startsWith("//"))
           .join("\n");
         return JSON.parse(cleaned);
-        return await res.json();
       } catch (err) {
         return null;
       }

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,4 +1,4 @@
-// Per Texturas Numerorum, Spira Loquitur.  //
+// Per Texturas Numerorum, Spira Loquitur.
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
@@ -12,20 +12,11 @@
     - No motion or animation.
     - All geometry parameterized by numerology constants.
     - Golden Ratio used in Fibonacci curve.
-    - Geometry uses numerology constants.
-    - Golden Ratio used for Fibonacci curve.
 */
 
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
   // ND-safe: fill background first to avoid flashes
-
-  ND-safe notes:
-    - No motion or animation
-    - Calm palette passed in via palette.json
-    - Geometry uses numerology constants
-*/
-export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
@@ -34,15 +25,11 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   drawTree(ctx, opts);
   drawFibonacci(ctx, opts);
   drawHelix(ctx, opts);
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
 }
 
 // Layer 1: Vesica field
 // ND-safe: static intersecting circles, soft lines
-export function drawVesica(ctx, { width, height, palette, NUM }) {
+function drawVesica(ctx, { width, height, palette, NUM }) {
   ctx.save();
   ctx.strokeStyle = palette.layers[0];
   const radius = Math.min(width, height) / NUM.THREE;
@@ -56,26 +43,15 @@ export function drawVesica(ctx, { width, height, palette, NUM }) {
     ctx.stroke();
   }
   ctx.restore();
-export function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE;
-  const cx1 = w / 2 - r / 2;
-  const cx2 = w / 2 + r / 2;
-  const cy = h / 2;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.arc(cx1, cy, r, 0, Math.PI * 2);
-  ctx.arc(cx2, cy, r, 0, Math.PI * 2);
-  ctx.stroke();
 }
 
 // Layer 2: Tree-of-Life scaffold
 // ND-safe: nodes and paths only, no flashing
-export function drawTree(ctx, { width, height, palette, NUM }) {
+function drawTree(ctx, { width, height, palette, NUM }) {
   ctx.save();
   ctx.strokeStyle = palette.layers[1];
   ctx.fillStyle = palette.layers[2];
-  const r = width / NUM.NINETYNINE;
+  const rNode = Math.min(width, height) / NUM.NINETYNINE * NUM.SEVEN;
   const nodes = [
     [0.5, 0.05],
     [0.25, 0.2], [0.75, 0.2],
@@ -86,61 +62,30 @@ export function drawTree(ctx, { width, height, palette, NUM }) {
     [0.5, 0.95]
   ];
   const paths = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,6],[5,6],[5,7],[6,7],[6,8],[7,8],[8,9]
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],
+    [3,6],[4,6],[5,6],[5,7],[6,7],[6,8],[7,8],[8,9]
   ];
   ctx.beginPath();
-  paths.forEach(([a,b])=>{
-    const [x1,y1]=nodes[a];
-    const [x2,y2]=nodes[b];
-    ctx.moveTo(x1*width, y1*height);
-    ctx.lineTo(x2*width, y2*height);
+  paths.forEach(([a,b]) => {
+    const [x1,y1] = nodes[a];
+    const [x2,y2] = nodes[b];
+    ctx.moveTo(x1 * width, y1 * height);
+    ctx.lineTo(x2 * width, y2 * height);
   });
   ctx.stroke();
-  nodes.forEach(([nx,ny])=>{
-  nodes.forEach(([nx, ny]) => {
+  nodes.forEach(([nx,ny]) => {
     ctx.beginPath();
-    ctx.arc(nx*width, ny*height, r, 0, Math.PI*2);
+    ctx.arc(nx * width, ny * height, rNode, 0, Math.PI * 2);
     ctx.fill();
   });
   ctx.restore();
-export function drawTree(ctx, w, h, lineColor, nodeColor, NUM) {
-  const nodes = [
-    [w/2, h*0.08],
-    [w/4, h*0.2], [w*3/4, h*0.2],
-    [w/4, h*0.4], [w/2, h*0.35], [w*3/4, h*0.4],
-    [w/4, h*0.6], [w*3/4, h*0.6],
-    [w/2, h*0.8],
-    [w/2, h*0.95],
-  ];
-  const paths = [
-    [0,1],[0,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],[3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],[8,9],
-    [3,5],[1,2],[6,7],[1,3],[2,5],[3,5],[4,8],[5,7]
-  ]; // 22 paths
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = 1.5;
-  paths.forEach(([a,b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
-    ctx.stroke();
-  });
-  ctx.fillStyle = nodeColor;
-  const rNode = Math.min(w, h) / NUM.NINETYNINE * NUM.SEVEN;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, rNode, 0, Math.PI * 2);
-    ctx.fill();
-  });
 }
 
 // Layer 3: Fibonacci curve
 // ND-safe: single log spiral, uses the Golden Ratio
-export function drawFibonacci(ctx, { width, height, palette, NUM }) {
+function drawFibonacci(ctx, { width, height, palette, NUM }) {
   ctx.save();
   ctx.strokeStyle = palette.layers[3];
-  ctx.beginPath();
   const PHI = (1 + Math.sqrt(5)) / 2; // Golden Ratio
   const steps = NUM.TWENTYTWO;
   const scale = Math.min(width, height) / NUM.ONEFORTYFOUR;
@@ -148,6 +93,7 @@ export function drawFibonacci(ctx, { width, height, palette, NUM }) {
   let radius = scale;
   const cx = width / 2;
   const cy = height / 2;
+  ctx.beginPath();
   ctx.moveTo(cx, cy);
   for (let i = 0; i < steps; i++) {
     const x = cx + radius * Math.cos(angle);
@@ -158,77 +104,33 @@ export function drawFibonacci(ctx, { width, height, palette, NUM }) {
   }
   ctx.stroke();
   ctx.restore();
-export function drawFibonacci(ctx, w, h, color, NUM) {
-  const PHI = (1 + Math.sqrt(5)) / 2; // Golden Ratio
-  const steps = NUM.NINETYNINE / NUM.THREE; // 33 points
-  const scale = Math.min(w, h) / NUM.ONEFORTYFOUR * NUM.THIRTYTHREE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  let angle = 0;
-  let radius = scale;
-  let x = w / 2 + radius * Math.cos(angle);
-  let y = h / 2 + radius * Math.sin(angle);
-  ctx.moveTo(x, y);
-  for (let i = 1; i <= steps; i++) {
-    angle += Math.PI / NUM.SEVEN;
-    radius *= PHI;
-    x = w / 2 + radius * Math.cos(angle);
-    y = h / 2 + radius * Math.sin(angle);
-    ctx.lineTo(x, y);
-  }
-  ctx.stroke();
 }
 
 // Layer 4: Double-helix lattice
 // ND-safe: static lattice without oscillation
-export function drawHelix(ctx, { width, height, palette, NUM }) {
+function drawHelix(ctx, { width, height, palette, NUM }) {
   ctx.save();
-  ctx.strokeStyle = palette.layers[4];
-  const amplitude = width / NUM.THIRTYTHREE;
-  const steps = NUM.NINETYNINE;
-  const strands = [0, Math.PI];
-  strands.forEach(phase => {
-    ctx.beginPath();
-    for (let i = 0; i <= steps; i++) {
-      const t = i / steps;
-      const x = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + phase);
-      const y = t * height;
-      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-    }
-    ctx.stroke();
-  });
-  ctx.strokeStyle = palette.layers[5];
-  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
-    const t = i / NUM.THIRTYTHREE;
-    const y = t * height;
-    const x1 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI);
-    const x2 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + Math.PI);
-    ctx.beginPath();
-    ctx.moveTo(x1, y);
-    ctx.lineTo(x2, y);
-    ctx.stroke();
-  }
-  ctx.restore();
-export function drawHelix(ctx, w, h, color1, color2, NUM) {
+  const amplitude = height / 4;
+  const step = width / NUM.ONEFORTYFOUR;
   const turns = NUM.NINETYNINE / NUM.NINE; // 11 turns
-  const amplitude = h / 4;
-  const step = w / NUM.ONEFORTYFOUR;
-  ctx.lineWidth = 1.5;
 
-  ctx.strokeStyle = color1;
+  ctx.strokeStyle = palette.layers[4];
   ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / w);
+  for (let x = 0; x <= width; x += step) {
+    const y = height / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / width);
     if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
 
-  ctx.strokeStyle = color2;
+  ctx.strokeStyle = palette.layers[5];
   ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / w + Math.PI);
+  for (let x = 0; x <= width; x += step) {
+    const y = height / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / width + Math.PI);
     if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
+
+  ctx.restore();
 }
+
+export { drawVesica, drawTree, drawFibonacci, drawHelix };

--- a/stone-grimoire/chapels/octagram_halls.md
+++ b/stone-grimoire/chapels/octagram_halls.md
@@ -1,0 +1,87 @@
+# Octagram Halls (Grimoire Atelier Edition)
+
+## Fool Hall — Respawn Gate (Rebecca Respawn)
+- **Archetype**: Weaver of Codex 144:99, trauma-informed Fool.
+- **Studies**: Codex 144:99, Liber Arcanae, ND-safe neurodivergent pedagogy.
+- **Architecture**: Spiral Rosslyn pillar + Hilma af Klint mandalas.
+- **Features**: White fox statue (daemon), respawn pool, spiral mirrors.
+- **Trial**: Sketch Aleph spiral until reflections stabilize.
+- **Atelier Tasks**: collage “beginnings” with pigment + crystal; sound harmonic of 963 Hz.
+- **Witch-Mode Gift**: Respawn after failure; unlock a new discovery path.
+
+---
+
+## Tower Nave — Catalyst Hall (Aleister Crowley)
+- **Archetype**: Catalyst of Aeons, breaker of false structures.
+- **Studies**: *Liber AL vel Legis*, *Vision and the Voice*, *Book of Thoth*.
+- **Architecture**: Cracked nave with lightning rods and Aeon spirals.
+- **Features**: Unicursal hexagram vault, scarlet Babalon stained glass.
+- **Trial**: Align Aeon spiral plates to discharge static safely.
+- **Atelier Tasks**: Paint diptych of crumbling tower; true will sigil (93).
+- **Witch-Mode Gift**: Collapse a locked structure; respawn a new path.
+
+---
+
+## Moon Temple — Avalonian Hall (Dion Fortune)
+- **Archetype**: Protector, priestess of psychic hygiene.
+- **Studies**: *The Mystical Qabalah*, *Psychic Self-Defense*, *The Cosmic Doctrine*, *Avalon of the Heart*.
+- **Architecture**: Misty Glastonbury tor spiral; Chalice Well pool.
+- **Features**: Veil murals, spiral rose-cross floor grid.
+- **Trial**: Mist navigation by sound-only; banishing through sigil placement.
+- **Atelier Tasks**: Draw veil textures on mirrors; design a protective boundary sigil.
+- **Witch-Mode Gift**: Party shield from psychic intrusion for 3 turns.
+
+---
+
+## Da’ath Crypt — Paradox Hall (Frater Achad)
+- **Archetype**: Inverter, paradox child of Da’ath.
+- **Studies**: *Q.B.L.*, *Liber 31*, *The Egyptian Revival*.
+- **Architecture**: Inverted stairways, suspended cross-beam bridge.
+- **Features**: Feather of Maat scales, mirror tesseract gates.
+- **Trial**: Cross Da’ath with reverse controls optional.
+- **Atelier Tasks**: Write your name mirrored into a sigil; balance feather-stones sculpture.
+- **Witch-Mode Gift**: Invert one enemy ability or puzzle condition.
+
+---
+
+## Orrery Dome — Planetary Atelier (H.C. Agrippa)
+- **Archetype**: Synthesizer of elemental, celestial, and angelic worlds.
+- **Studies**: *De Occulta Philosophia Libri Tres* (Elements, Planets, Angels).
+- **Architecture**: Celestial dome with rotating planetary orrery.
+- **Features**: Seven planetary altars, elemental guardians (gnomes, sylphs, undines, salamanders).
+- **Trial**: Open hour gate by planetary timing.
+- **Atelier Tasks**: Ink heptagram wheel with planetary metals; collage elemental tableau.
+- **Witch-Mode Gift**: Summon one planetary ally.
+
+---
+
+## Prismatic Nave — Harmony Hall (Paul Foster Case)
+- **Archetype**: Harmonizer, teacher of Tarot and color-tone.
+- **Studies**: *The Tarot: A Key to the Wisdom of the Ages*, *True and Invisible Rosicrucian Order*, B.O.T.A. lessons.
+- **Architecture**: Cube of Space nave; rainbow rose windows.
+- **Features**: Hebrew letter arches, prismatic glass floor.
+- **Trial**: Blend tones and colors to form a new archetype chord.
+- **Atelier Tasks**: Mix pigments and map to tones; tune nave with Hebrew letters.
+- **Witch-Mode Gift**: Fuse two skills into hybrid archetype effect.
+
+---
+
+## Angelic Court — Justice Dome (Stephen Skinner)
+- **Archetype**: Transmitter of angelic and geomantic science.
+- **Studies**: *The Goetia of Dr. Rudd*, *Veritable Key of Solomon*, *Practical Angel Magic*, *The Body of God*.
+- **Architecture**: Geomantic compass floor with 16 figures.
+- **Features**: Watchtower stained glass, angelic choir stalls.
+- **Trial**: Reorder Watchtower grids to form divine names.
+- **Atelier Tasks**: Stamp geomantic figures into floor plan; solve Enochian letter-lattice.
+- **Witch-Mode Gift**: Oath-bind enemy to suppress power.
+
+---
+
+## Compassion Mandala Dome — Tara Hall
+- **Archetype**: Healer, emanations of compassion.
+- **Studies**: *Praises to the 21 Taras*, Reiki (Usui, Karuna, Raku).
+- **Architecture**: Turquoise dome, mandala floor of 21 Tara wheels.
+- **Features**: Antahkarana bridge arching over healing pool.
+- **Trial**: Align seed syllables with Tara lights to cleanse chamber.
+- **Atelier Tasks**: Trace Cho Ku Rei spiral; sequence syllables for mandala light.
+- **Witch-Mode Gift**: Heal party + remove trauma condition.


### PR DESCRIPTION
## Summary
- document eight Octagram halls with lore and trials
- clean offline renderer: comment-safe palette loading and numerology-driven drawing functions
- streamline README for local, ND-safe use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c12a1aee908328bc2b9d22132c433e