### PR TITLE
feat: add offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,10 +1,6 @@
 Per Texturas Numerorum, Spira Loquitur.  //
 # Cosmic Helix Renderer
 
-Static offline renderer for the Codex 144:99 geometry helix. Double-click `index.html` to open in any modern browser. No server and no network needed.
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Double-click `index.html` in any modern browser—no server or network calls.
-Static offline renderer for the Codex 144:99 geometry helix. Double-click `index.html` to open in any modern browser.
-No server, no network.
 Static offline canvas renderer for layered sacred geometry in Codex 144:99. Double-click `index.html` in any modern browser—no server or network calls.
 
 ## Files
@@ -26,13 +22,10 @@ Static offline canvas renderer for layered sacred geometry in Codex 144:99. Doub
 
 ## Customization
 - Edit `data/palette.json` to change colors.
-- Optionally add `data/constants.json` with numerology values to tweak proportions.
+- Optionally add `data/constants.json` with numerology values.
 
 ## Local Use
 Open `index.html` directly in any modern browser.
-- No motion, autoplay, or external requests.
-- Calming contrast and soft colors.
-- Geometry uses numerology constants 3,7,9,11,22,33,99,144.
 
 ## Tests
 Run local checks:
@@ -40,8 +33,7 @@ Run local checks:
 ```sh
 npm test
 ```
+
 ## Notes
 - ND-safe: calm contrast, no motion, optional palette override.
-- All geometry uses constants 3, 7, 9, 11, 22, 33, 99, 144.
-- If `data/palette.json` is missing, a built-in fallback palette renders instead.
 - Works completely offline; open `index.html` directly.

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
           .filter(line => !line.trim().startsWith("//"))
           .join("\n");
         return JSON.parse(cleaned);
-        return await res.json();
       } catch (err) {
         return null;
       }

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -4,36 +4,23 @@
   ND-safe static renderer for layered sacred geometry.
 
   Layers:
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
-    3) Fibonacci curve (log spiral polyline; static)
-    4) Double-helix lattice (two phase-shifted strands)
-  Notes:
-    - No motion or animation.
-    - All geometry parameterized by numerology constants.
-    - Golden Ratio used in Fibonacci curve.
-    - Geometry uses numerology constants.
-    - Golden Ratio used for Fibonacci curve.
+    1) Vesica field (intersecting circle grid)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
+    4) Double-helix lattice (two strands with rungs)
+
+  ND-safe choices:
+    - No motion or animation; everything renders once.
+    - Calming palette supplied externally; high-contrast lines.
+    - Pure functions with numerology constants 3,7,9,11,22,33,99,144.
 */
 
-export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM } = opts;
-  // ND-safe: fill background first to avoid flashes
-
-  ND-safe notes:
-    - No motion or animation
-    - Calm palette passed in via palette.json
-    - Geometry uses numerology constants
-*/
 export function renderHelix(ctx, { width, height, palette, NUM }) {
+  // Fill background first to avoid flashes.
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // Layer order preserves contemplative depth
-  drawVesica(ctx, opts);
-  drawTree(ctx, opts);
-  drawFibonacci(ctx, opts);
-  drawHelix(ctx, opts);
+  // Layer order preserves contemplative depth.
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
@@ -41,41 +28,25 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
 }
 
 // Layer 1: Vesica field
-// ND-safe: static intersecting circles, soft lines
-export function drawVesica(ctx, { width, height, palette, NUM }) {
-  ctx.save();
-  ctx.strokeStyle = palette.layers[0];
-  const radius = Math.min(width, height) / NUM.THREE;
-  const offset = radius / NUM.NINE;
-  const cy = height / 2;
-  for (let i = -NUM.THREE; i <= NUM.THREE; i++) {
-    const cx = width / 2 + i * offset * NUM.SEVEN;
-    ctx.beginPath();
-    ctx.arc(cx - radius / NUM.THREE, cy, radius, 0, Math.PI * 2);
-    ctx.arc(cx + radius / NUM.THREE, cy, radius, 0, Math.PI * 2);
-    ctx.stroke();
-  }
-  ctx.restore();
-export function drawVesica(ctx, w, h, color, NUM) {
+// ND-safe: static intersecting circles, soft strokes.
+function drawVesica(ctx, w, h, color, NUM) {
   const r = Math.min(w, h) / NUM.THREE;
-  const cx1 = w / 2 - r / 2;
-  const cx2 = w / 2 + r / 2;
+  const step = r / NUM.NINE;
   const cy = h / 2;
   ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.arc(cx1, cy, r, 0, Math.PI * 2);
-  ctx.arc(cx2, cy, r, 0, Math.PI * 2);
-  ctx.stroke();
+  ctx.lineWidth = 1;
+  for (let i = -NUM.THREE; i <= NUM.THREE; i++) {
+    const cx = w / 2 + i * step * NUM.SEVEN;
+    ctx.beginPath();
+    ctx.arc(cx - r / NUM.THREE, cy, r, 0, Math.PI * 2);
+    ctx.arc(cx + r / NUM.THREE, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
 }
 
 // Layer 2: Tree-of-Life scaffold
-// ND-safe: nodes and paths only, no flashing
-export function drawTree(ctx, { width, height, palette, NUM }) {
-  ctx.save();
-  ctx.strokeStyle = palette.layers[1];
-  ctx.fillStyle = palette.layers[2];
-  const r = width / NUM.NINETYNINE;
+// ND-safe: simple nodes and paths only.
+function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
   const nodes = [
     [0.5, 0.05],
     [0.25, 0.2], [0.75, 0.2],
@@ -86,68 +57,39 @@ export function drawTree(ctx, { width, height, palette, NUM }) {
     [0.5, 0.95]
   ];
   const paths = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,6],[5,6],[5,7],[6,7],[6,8],[7,8],[8,9]
-  ];
-  ctx.beginPath();
-  paths.forEach(([a,b])=>{
-    const [x1,y1]=nodes[a];
-    const [x2,y2]=nodes[b];
-    ctx.moveTo(x1*width, y1*height);
-    ctx.lineTo(x2*width, y2*height);
-  });
-  ctx.stroke();
-  nodes.forEach(([nx,ny])=>{
-  nodes.forEach(([nx, ny]) => {
-    ctx.beginPath();
-    ctx.arc(nx*width, ny*height, r, 0, Math.PI*2);
-    ctx.fill();
-  });
-  ctx.restore();
-export function drawTree(ctx, w, h, lineColor, nodeColor, NUM) {
-  const nodes = [
-    [w/2, h*0.08],
-    [w/4, h*0.2], [w*3/4, h*0.2],
-    [w/4, h*0.4], [w/2, h*0.35], [w*3/4, h*0.4],
-    [w/4, h*0.6], [w*3/4, h*0.6],
-    [w/2, h*0.8],
-    [w/2, h*0.95],
-  ];
-  const paths = [
-    [0,1],[0,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],[3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],[8,9],
-    [3,5],[1,2],[6,7],[1,3],[2,5],[3,5],[4,8],[5,7]
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,6],[5,6],
+    [5,7],[6,7],[6,8],[7,8],[8,9],[1,3],[2,4],[3,4],[6,7],[3,5],[4,5],[4,8]
   ]; // 22 paths
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 1;
   paths.forEach(([a,b]) => {
     ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
+    ctx.moveTo(nodes[a][0] * w, nodes[a][1] * h);
+    ctx.lineTo(nodes[b][0] * w, nodes[b][1] * h);
     ctx.stroke();
   });
   ctx.fillStyle = nodeColor;
   const rNode = Math.min(w, h) / NUM.NINETYNINE * NUM.SEVEN;
-  nodes.forEach(([x,y]) => {
+  nodes.forEach(([nx, ny]) => {
     ctx.beginPath();
-    ctx.arc(x, y, rNode, 0, Math.PI * 2);
+    ctx.arc(nx * w, ny * h, rNode, 0, Math.PI * 2);
     ctx.fill();
   });
 }
 
 // Layer 3: Fibonacci curve
-// ND-safe: single log spiral, uses the Golden Ratio
-export function drawFibonacci(ctx, { width, height, palette, NUM }) {
-  ctx.save();
-  ctx.strokeStyle = palette.layers[3];
-  ctx.beginPath();
-  const PHI = (1 + Math.sqrt(5)) / 2; // Golden Ratio
-  const steps = NUM.TWENTYTWO;
-  const scale = Math.min(width, height) / NUM.ONEFORTYFOUR;
+// ND-safe: static logarithmic spiral using the Golden Ratio.
+function drawFibonacci(ctx, w, h, color, NUM) {
+  const PHI = (1 + Math.sqrt(5)) / 2;
+  const steps = NUM.THIRTYTHREE;
+  const scale = Math.min(w, h) / NUM.ONEFORTYFOUR;
   let angle = 0;
   let radius = scale;
-  const cx = width / 2;
-  const cy = height / 2;
+  const cx = w / 2;
+  const cy = h / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
   ctx.moveTo(cx, cy);
   for (let i = 0; i < steps; i++) {
     const x = cx + radius * Math.cos(angle);
@@ -157,78 +99,37 @@ export function drawFibonacci(ctx, { width, height, palette, NUM }) {
     angle += Math.PI / NUM.SEVEN;
   }
   ctx.stroke();
-  ctx.restore();
-export function drawFibonacci(ctx, w, h, color, NUM) {
-  const PHI = (1 + Math.sqrt(5)) / 2; // Golden Ratio
-  const steps = NUM.NINETYNINE / NUM.THREE; // 33 points
-  const scale = Math.min(w, h) / NUM.ONEFORTYFOUR * NUM.THIRTYTHREE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  let angle = 0;
-  let radius = scale;
-  let x = w / 2 + radius * Math.cos(angle);
-  let y = h / 2 + radius * Math.sin(angle);
-  ctx.moveTo(x, y);
-  for (let i = 1; i <= steps; i++) {
-    angle += Math.PI / NUM.SEVEN;
-    radius *= PHI;
-    x = w / 2 + radius * Math.cos(angle);
-    y = h / 2 + radius * Math.sin(angle);
-    ctx.lineTo(x, y);
-  }
-  ctx.stroke();
 }
 
 // Layer 4: Double-helix lattice
-// ND-safe: static lattice without oscillation
-export function drawHelix(ctx, { width, height, palette, NUM }) {
-  ctx.save();
-  ctx.strokeStyle = palette.layers[4];
-  const amplitude = width / NUM.THIRTYTHREE;
+// ND-safe: two static strands with cross rungs; no oscillation.
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  const turns = NUM.ELEVEN;
+  const amplitude = w / NUM.THIRTYTHREE;
   const steps = NUM.NINETYNINE;
-  const strands = [0, Math.PI];
-  strands.forEach(phase => {
+  ctx.lineWidth = 1;
+  [colorA, colorB].forEach((col, idx) => {
+    ctx.strokeStyle = col;
     ctx.beginPath();
     for (let i = 0; i <= steps; i++) {
       const t = i / steps;
-      const x = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + phase);
-      const y = t * height;
+      const x = w / 2 + amplitude * Math.sin(turns * t * Math.PI * 2 + idx * Math.PI);
+      const y = t * h;
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
   });
-  ctx.strokeStyle = palette.layers[5];
+  ctx.strokeStyle = colorB;
   for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
     const t = i / NUM.THIRTYTHREE;
-    const y = t * height;
-    const x1 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI);
-    const x2 = width / 2 + amplitude * Math.sin(NUM.ELEVEN * t * Math.PI + Math.PI);
+    const y = t * h;
+    const x1 = w / 2 + amplitude * Math.sin(turns * t * Math.PI * 2);
+    const x2 = w / 2 + amplitude * Math.sin(turns * t * Math.PI * 2 + Math.PI);
     ctx.beginPath();
     ctx.moveTo(x1, y);
     ctx.lineTo(x2, y);
     ctx.stroke();
   }
-  ctx.restore();
-export function drawHelix(ctx, w, h, color1, color2, NUM) {
-  const turns = NUM.NINETYNINE / NUM.NINE; // 11 turns
-  const amplitude = h / 4;
-  const step = w / NUM.ONEFORTYFOUR;
-  ctx.lineWidth = 1.5;
-
-  ctx.strokeStyle = color1;
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / w);
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  ctx.strokeStyle = color2;
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h / 2 + amplitude * Math.sin((turns * 2 * Math.PI * x) / w + Math.PI);
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
 }
+
+export { drawVesica, drawTree, drawFibonacci, drawHelix };


### PR DESCRIPTION
## Summary
- add ND-safe `helix-renderer.mjs` module for Vesica, Tree-of-Life, Fibonacci, and double-helix layers
- load palette from `palette.json` with local fallback in `index.html`
- document offline renderer usage in `README_RENDERER.md`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6136eb7e08328b6839f44e4381e5f