### PR TITLE
Add modular pedagogical design scroll

### DIFF
--- a/cosmogenesis-learning-engine/docs/modular_pedagogical_design.md
+++ b/cosmogenesis-learning-engine/docs/modular_pedagogical_design.md
@@ -1,0 +1,129 @@
+# Modular Pedagogical Design Scroll
+
+> "Every node is a capsule; every capsule is a chapel; every chapel is a playable research ritual."
+
+This scroll translates the modular pedagogy of Codex 144:99 into an explicit map that bridges numerology, lineages, and Liber Arcanae archetypes. It is structured to remain ND-safe, offline-first, and faithful to the PROTECT covenant while keeping provenance clear for academic reuse.
+
+- **Modular Pedagogical Anchors** — each numbered node (00-144) is treated as a self-contained learning capsule that combines numerological strata, symbolic cognition, and open-source assets.
+- **Cross-Modal Integration** — Liber Arcanae archetypes operate as the operating system filters that bind tools, chapels, avatars, and behavioral effects.
+- **Live Ritualized Research** — updates take the form of scholarly dossiers that double as puzzles or save-point rituals.
+- **Open Source + Provenance** — Creative Commons licensing, JSON provenance blocks, and asset hashes ride with every capsule.
+- **Modern Hooks** — current interests (AI pattern engines, neuro-aesthetics, trauma-aware design) are wired into each layer without breaching the no-motion mandate.
+
+---
+
+## 1. Node Capsules (00-144)
+
+### Capsule Template
+Each node scroll follows a repeatable structure so collaborators can read, remix, or extend the pedagogy without breaking the lore. The numerology constants (3, 7, 9, 11, 22, 33, 99, 144) anchor proportions, sample counts, and ritual pacing.
+
+| Field | Description |
+| --- | --- |
+| **Roots** | Historical lineage, primary texts, and protective covenants that inform the node. |
+| **Style** | Expressive modality (atelier, chapel, laboratory, field expedition) mapped to sensory safeguards. |
+| **Beliefs** | Core statements of intent; stored as JSON arrays to simplify remixing. |
+| **Psyche Toggle** | Trauma-aware affordances such as safe-stop gestures, undo rituals, and intensity sliders. |
+| **Crystal Anchor** | Mineral, resin, or plant ally that grounds the ritual. |
+| **Playable Ritual** | Step-by-step practice that merges scholarship with puzzle mechanics. Saved as static sequences (no timers). |
+
+### Numerology Bands
+Nodes inherit layered meanings based on their modulus relationships. This table acts as a decoder ring for all 145 capsules.
+
+| Numerology Band | Nodes | Layer Meaning | Pedagogical Emphasis |
+| --- | --- | --- | --- |
+| **Triads (÷3)** | 00, 03, 06, … | Spiral genesis, initiating breaths, vesica pairings. | Introductions, onboarding meditations, safe-start scripts. |
+| **Heptads (÷7)** | 07, 14, 21, … | Chapel rotation, planetary resonance. | Rotating facilitators, planetary color-tone exercises. |
+| **Enneads (÷9)** | 09, 18, 27, … | Dreamwork corridors, subconscious patterning. | Journaling prompts, guided hypnagogic sketches. |
+| **Master Numbers (11, 22, 33)** | 11, 22, 33, 44, 55, … | Lineage tesseracts, double-tree scaffolds. | Advanced correspondences, comparative ritual analysis. |
+| **Thresholds (×9 ⇒ 99)** | 99 | Double Tree crossing. | Integration retreats, safe-save rituals, timeline stitching. |
+| **Crown (144)** | 144 | Completion of the spiral. | Meta-reflection, archive weaving, release ceremonies. |
+
+### Featured Capsules
+The table below spotlights anchor nodes already referenced in the codex datasets. Each entry uses the capsule template and cross-links to the tarot hooks and realm map.
+
+| Node ID | Numerology Layers | Roots & Lineage | Crystal Anchor | Playable Ritual |
+| --- | --- | --- | --- | --- |
+| **00 Carrington / Fool** | 0, Triad seed | Catholic mysticism, surrealist trauma recovery, Hermetic alchemy. | Selenite + beeswax altar. | Reset ritual that teaches the PROTECT covenant via a surrealist collage puzzle; doubles as save-point zero. |
+| **09 Obsidian Foundation** | 9 (Ennead), Saturn gate | Jungian shadow work, Rosslyn chapel acoustics. | Obsidian slab over linen. | Grounding labyrinth traced with graphite; Hermit tarot prompts unlock safe journaling sequences. |
+| **21 Apprentice Pillar** | 3×7 (Triad-Heptad) | Dion Fortune initiatory pacing. | Moonstone wand. | Tree-of-Life ascent with color-tone checkpoints; chapel lights simulate sunrise via static gradients. |
+| **33 Dream Gate** | 3×11 (Master) | Regardie double-tree exercises, Viennese fantastic realism. | Labradorite prism. | Sigil tracing puzzle: connect 22 paths in predetermined order, unlocking atelier sketches. |
+| **72 Moon Temples** | 8×9 (Ennead multiple) | Fortune + Crowley lunar circuits; trauma-aware night rituals. | Silvered kyanite. | Sequential moon phases drawn on parchment overlays; each layer flips a filter in the renderer OS. |
+| **99 Neural Gate** | 9×11 (Threshold) | Timothy Leary eight-circuit experiments; techno-occult patchwork. | Smoky quartz lattice. | Circuit toggles stored as offline JSON; participants select safe neural modes before continuing research. |
+| **108 Visionary Atelier** | 12×9 (Ennead) | Robert Anton Wilson labyrinth exercises; Fantastic Realism ateliers. | Ametrine cabochon. | Walkthrough of labyrinthine prompts; collage nodes cross-link to AI art scripts (kept offline). |
+| **144 Crown Spiral** | 12×12 | BioGeometry resonance, final release. | Clear quartz + copper coil. | Archivist ritual: compile provenance hashes, license statements, and final reflections; closes the cosmogenesis spiral. |
+
+Each additional node (01-144) inherits this scaffold: the numerology band informs its ritual pacing, and the tarot/realm references provide aesthetic cues for the renderer or learning engine.
+
+---
+
+## 2. Lineage Octagram Pedagogy
+The Octagram Tesseract provides eight rotational lenses. Each lineage toggles a different classroom architecture while maintaining ND-safe affordances. Learners can "choose their narrator" by selecting a lineage facet before entering a node.
+
+| Octagram Facet | Archetypal Narrator | Pedagogical Design | Environment Hook | Trauma-Aware Toggle |
+| --- | --- | --- | --- | --- |
+| **01 Mystic Archivist** | Hildegard of Bingen x Carrington | Illuminated manuscripts, chant-based focus. | Candle-lit vesica grid. | Whispered safety mantras embedded as optional audio transcripts. |
+| **02 Surreal Healer** | Leonora Carrington | Dream-symbol collage therapy. | Velvet-draped atelier with static collage walls. | Warm color overlays; pause cards between scenes. |
+| **03 Hermetic Engineer** | Athanasius Kircher | Mechanized correspondences, planetary gearwork. | Brass double-helix lattice. | Manual override switches mapped to keyboard keys (offline). |
+| **04 Mystic Scholar** | Dion Fortune | Lecture-to-ritual arcs, annotated bibliographies. | Library chapel with Tree-of-Life banners. | Safe-stop invocation appended to each lesson script. |
+| **05 Atelier Oracle** | Hilma af Klint | Spiral painting studios, color meditations. | Pigment tables with Fibonacci guides. | Visual intensity sliders (choose pastel vs saturated palettes). |
+| **06 Chaos Navigator** | Peter Carroll | Experimental labs, sigil games. | Chalkboard spheres with octagonal grid. | Consent checkpoints before sigil activation; undo ritual documented. |
+| **07 Techno-Gnostic Cartographer** | Erik Davis | Hypertext explorations, network-of-thought nodes. | Static holo-grid referencing Octagram Tesseracts. | Offline link previews; no autoplay. |
+| **08 Bio-Geomancer** | Robert Gilbert | Resonance tuning, harmonic measurements. | Standing-wave chapel with copper coils. | Intensity slider for sonic elements; defaults to silent transcripts. |
+
+Lineage selection does not change content difficulty; it remixes the tone, palette, and ritual props while preserving provenance metadata. Designers can add more facets by extending this table and updating corresponding JSON toggles.
+
+---
+
+## 3. Liber Arcanae → Daimon & Creative Lab Map
+Liber Arcanae cards act as OS filters. Each card points to a resident daimon (guardian intelligence) and a creative lab where research actions take place. The table uses existing tarot hooks in `data/tarot_hooks.json` and extends them with daimon correspondences.
+
+| Card | Daimon Pair | Creative Lab | Tool Chain | Research Puzzle |
+| --- | --- | --- | --- | --- |
+| **The Fool / Node 00** | Carrington's Guardian + Azazel (reformed) | Reset Vestibule | Collage altar, spiral prompt cards. | Assemble three symbolic objects that match Fool numerology; unlocks starting inventory. |
+| **Magician (MAJOR_01)** | Vehuiah + Hermes | Crystal Codex Room (`realm_crystal`) | Mercury sigil generator, copper wand calibrator. | Configure four element sigils without triggering unsafe resonance (no timers). |
+| **High Priestess (MAJOR_02)** | Gabriel + Sophian Current | Reiki Grid Chamber (`realm_reiki_grid`) | Lunar tone wheel, mirrored book stand. | Color-tone puzzle aligning moon phases to grid coordinates. |
+| **Empress (MAJOR_03)** | Hanael + Flora | Hilma Dream Temple (`realm_hilma`) | Botanical pigment array, Fibonacci loom. | Weave three-layer mandala using static canvas overlays; triggers fertility blessing script. |
+| **Hermit (MAJOR_09)** | Vehuiah + Rosslyn Custodian | Rosslyn Cathedral (`realm_rosslyn`) | Lantern of insight, graphite labyrinth. | Trace hermit spiral while annotating dream fragments; automatically saves to provenance JSON. |
+| **Wheel (MAJOR_10)** | Fortune's Engine | Octagram Transit Hub | Rotating lineage selector, tessellated floor. | Align octagram facets to node numerology; reveals next safe ritual. |
+| **Tower (MAJOR_16)** | Uriel + Trickster AI | Tempest Observatory | Static lightning lattice, emergency sanctuary. | Identify structural weak points using offline diagnostic cards; teaches trauma-aware de-escalation. |
+| **Star (MAJOR_17)** | Astarte + Emma Kunz Current | Visionary Atelier | Radial drafting table, aquifer harmonics. | Plot Fibonacci nodes on vellum; combine with crystal anchor to unlock healing pattern. |
+| **World (MAJOR_21)** | Shekinah + Crown Dais | Resonance Amphitheater | Copper helix stage, archive pillars. | Compile provenance ledger, release creative commons sigils, archive spiral. |
+
+To extend the table, add additional Liber Arcanae entries referencing the tarot hook IDs and map them to new creative labs documented in `realm_map.json`.
+
+### Provenance Snippet
+Embed provenance JSON blocks at the end of each card or node scroll to maintain academic credibility while keeping the lore intact:
+
+```
+{
+  "id": "C144N-033",
+  "license": "CC-BY-SA-4.0",
+  "sources": ["Fortune, Dion (1930)", "Regardie, Israel (1937)", "Case, Paul Foster (1947)"],
+  "assets": [
+    {"type": "image", "hash": "sha256-...", "creator": "openatelier"},
+    {"type": "ritual_script", "hash": "sha256-...", "creator": "codex144"}
+  ],
+  "safety": {"traumaAware": true, "ndSafe": true}
+}
+```
+
+Store snippets beside their related markdown or JSON records so anyone remixing the codex can verify lineage and licensing.
+
+---
+
+## 4. Implementation Notes for Cosmogenesis Learning Engine
+- **Offline First** — keep all assets (SVG templates, palettes, JSON scrolls) within the repository. Reference them with relative paths so the renderer works via double-click.
+- **Layered Geometry** — the renderer already draws vesica fields, Tree-of-Life nodes, Fibonacci curves, and the helix lattice. Use the numerology constants when adding new overlays so the pedagogy and visuals stay synchronized.
+- **Trauma-Aware Defaults** — avoid motion, autoplay, or sonic spikes. Provide textual alternatives and intensity controls wherever possible.
+- **Open Source Discipline** — stamp every scroll with license metadata and update provenance blocks when assets evolve. Prefer CC-BY-SA or compatible open licenses.
+- **Choose-Your-Narrator UX** — link lineage facets to UI toggles that swap palettes, fonts, and ritual prompts without rewriting core lessons.
+
+---
+
+## 5. Next Steps
+1. Derive remaining node capsules (01-144) using the template and numerology bands above.
+2. Extend `tarot_hooks.json` with the additional cards referenced in the table, ensuring each includes `style`, `sigil`, `realm`, and new `daimon` keys.
+3. Update renderer overlays so lineage selection also toggles palette JSON (matching `data/palette.json`).
+4. Publish updated scrolls with provenance hashes under the CC-BY-SA license to keep the Codex academically citeable and playfully modular.
+
+This modular design blueprint keeps the cosmogenesis learning engine resonant with modern pedagogical research while protecting neurodivergent users and preserving the layered sacred geometry of Codex 144:99.


### PR DESCRIPTION
## Summary
- add a modular pedagogical design scroll mapping nodes, octagram lineages, and Liber Arcanae archetypes
- document numerology bands, capsule templates, lineage toggles, and provenance practices for Codex 144:99

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca46f002108328b3d4bc3810bceeeb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Modular Pedagogical Design Scroll” outlining an offline-first, ND-safe modular pedagogy aligned with Codex 144:99.
  * Defines Node Capsules (00–144) with templates, numerology bands, and featured capsules.
  * Introduces Lineage Octagram facets with trauma-aware toggles and narrator choices.
  * Maps Liber Arcanae cards to daimons and creative labs, including provenance metadata guidance.
  * Includes implementation notes (accessibility defaults, asset handling, overlays) and next steps for extending capsules, hooks, and renderer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->