### PR TITLE
Clean offline helix renderer files

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,110 +3,27 @@
 Static offline canvas renderer for layered sacred geometry in Codex 144:99. Double-click `index.html` in any modern browser; no server or network access is required.
 
 ## Files
-- `index.html` - Entry document with a 1440x900 canvas, palette loader, and fallback status note.
+- `index.html` - entry document with a 1440x900 canvas, palette loader, and fallback status note.
 - `js/helix-renderer.mjs` - ES module exposing `renderHelix` plus pure helpers for each layer.
-- `data/palette.json` - Optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-1. **Vesica field** - Nine-by-seven vesica grid grounds the scene.
-2. **Tree-of-Life scaffold** - Ten sephirot and twenty-two paths mapped with numerology spacing.
-3. **Fibonacci curve** - Static golden spiral drawn with steady sampling (no animation).
-4. **Double-helix lattice** - Two phase-shifted strands with calm crossbars to maintain depth.
-
-## ND-safe Design
-- No motion, autoplay, or flashing effects; each layer renders once for sensory calm.
-- Palette loads from `data/palette.json`; when unavailable the fallback palette renders and a notice appears in the header.
-- Colors and spacing maintain readable contrast while referencing numerology constants 3, 7, 9, 11, 22, 33, 99, and 144.
-- Pure drawing helpers keep the geometry transparent so adaptations do not disturb existing lore.
-
-## Local Use
-1. Keep the three files in their current folders.
-2. Optionally adjust `data/palette.json` to fit lineage palettes while honoring WCAG AA contrast.
-3. Open `index.html` directly (double-click). Modern Chromium, Firefox, and WebKit builds render the scene offline.
-4. If the browser blocks file fetches, the fallback palette ensures the canvas still renders safely.
-
-This renderer is intentionally lightweight: no workflows, no dependencies, and no background services. Geometry is calculated on demand by small pure functions so the layered cosmology stays legible and trauma-informed.
-Static offline HTML5 canvas renderer for the layered cosmology in Codex 144:99. Double-click `index.html` in any modern browser; no server or network access is required.
-
-## Files
-- `index.html` - entry document with 1440x900 canvas, palette loader, and fallback status note.
-- `js/helix-renderer.mjs` - ES module exposing `renderHelix` plus pure helpers for each geometric layer.
 - `data/palette.json` - optional ND-safe palette override (background, ink, and six layer hues).
 - `README_RENDERER.md` - this usage and safety guide.
 
-## Layered Output
-1. **Vesica field** - repeating vesica grid grounds the composition.
-2. **Tree-of-Life scaffold** - ten nodes and twenty-two paths mapped with numerology spacing.
+## Rendered Layers
+1. **Vesica field** - intersecting circles establish the base grid and depth.
+2. **Tree-of-Life scaffold** - ten sephirot and twenty-two paths mapped with numerology spacing.
 3. **Fibonacci curve** - static golden spiral drawn with gentle sampling (no animation).
-4. **Double-helix lattice** - two phase-shifted strands plus steady rungs to preserve depth.
-
-## ND-safe Design Choices
-- No motion, autoplay, or flashing effects; geometry renders once on load.
-- Calm palette with readable contrast; fallback palette prevents blank screens if data is missing.
-- Helper functions are small and pure so adjustments stay reversible and lore-safe.
-- Geometry parameters derive from sacred numerology constants (3, 7, 9, 11, 22, 33, 99, 144) for traceable symbolism.
-
-## Local Use
-1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
-2. Optionally adjust `data/palette.json` to suit your lighting conditions (six layer colors are expected).
-3. Open `index.html` directly (double-click). Modern browsers such as Firefox or Chromium-based builds render without additional steps.
-4. If palette loading fails due to local file sandboxing, the built-in fallback palette renders and the header reports the safe state.
-
-This renderer is intentionally lightweight: no bundlers, no workflows, and no external dependencies. All geometry is calculated on demand by pure functions to honor the cathedral protocol.
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Open `index.html` directly in any modern browser; no server, workflow, or network call is required.
-
-## Files
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Open `index.html` directly in any modern browser; no server, workflow, or network call is required.
-
-## Files
-- `index.html` - Entry point with 1440x900 canvas, status notice, and palette fallback logic.
-- `js/helix-renderer.mjs` - ES module that draws the four layers using small pure helpers.
-- `data/palette.json` - Optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-1. **Vesica field** - Nine intersecting circles form the grounding grid.
-2. **Tree-of-Life scaffold** - Ten nodes and twenty-two paths plotted with numerology spacing.
-3. **Fibonacci curve** - Static golden spiral using calm sampling (no animation).
-4. **Double-helix lattice** - Two phase-shifted strands plus steady rungs for depth.
+4. **Double-helix lattice** - two phase-shifted strands plus steady rungs for layered geometry.
 
 ## ND-safe Design Notes
-- No motion, autoplay, or flashing effects; everything renders once when the page loads.
-- Palette loads from local data; if `data/palette.json` is missing, a safe fallback palette renders and a notice appears in the header.
-- Colors and spacing follow a trauma-informed hierarchy to support gentle contrast.
-- Geometry parameters derive from numerology constants 3, 7, 9, 11, 22, 33, 99, and 144 to honor the cosmology.
-
-## Local Use
-1. Keep the three files in the same relative folders.
-2. Optionally adjust `data/palette.json` to match your desired calm palette.
-3. Double-click `index.html`. Modern browsers such as Firefox or Chromium-based builds render it offline without extra steps.
-4. If palette loading fails because of local file sandbox rules, the fallback palette still renders and the status note confirms the safe mode.
-
-All geometry code is heavily commented so future integrations can extend the lattice without disturbing existing lore.
-- `index.html` — entry document with a 1440x900 canvas, palette loader, and fallback notice.
-- `js/helix-renderer.mjs` — ES module exposing `renderHelix` plus pure helpers for each layer.
-- `data/palette.json` — optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-- `index.html` — entry document with a 1440x900 canvas, palette loader, and fallback notice.
-- `js/helix-renderer.mjs` — ES module exposing `renderHelix` plus pure helpers for each layer.
-- `data/palette.json` — optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-1. **Vesica field** — intersecting circles establish the base grid and depth.
-2. **Tree-of-Life scaffold** — ten sephirot and twenty-two paths mapped to numerology constants.
-3. **Fibonacci curve** — static Golden Ratio spiral sampled gently for calm focus.
-4. **Double-helix lattice** — two phase-shifted strands with crossbars to preserve layered geometry.
-
-## ND-safe Design Notes
-- No motion, autoplay, or flashing effects; the scene renders once on load.
+- No motion, autoplay, or flashing effects; the scene renders once when the page loads.
 - Palette loads locally; if `data/palette.json` is missing or blocked, a built-in fallback palette renders and the header displays a notice.
 - Colors follow a calm contrast hierarchy to support trauma-informed use.
 - Geometry parameters derive from sacred numerology constants (3, 7, 9, 11, 22, 33, 99, 144) for traceable symbolism.
 
 ## Local Use
-1. Keep the three files in their existing folders.
+1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
 2. Optionally adjust `data/palette.json` with six layer hues that meet your contrast needs.
-3. Open `index.html` directly (double-click). Modern browsers such as Firefox or Chromium-based builds render without additional steps.
-4. If palette loading fails due to local file sandboxing, the fallback palette still renders safely.
+3. Double-click `index.html`. Modern browsers such as Firefox or Chromium-based builds render it offline without extra steps.
+4. If palette loading fails because of local file sandbox rules, the fallback palette still renders and the status note confirms the safe mode.
 
-This renderer stays intentionally lightweight: no bundlers, no dependencies, and no workflows. All geometry is calculated by small pure functions to honour the project's layered cosmology without disturbing existing lore.
+This renderer stays intentionally lightweight: no bundlers, no workflows, and no external dependencies. All geometry is calculated by small pure functions to honor the project's layered cosmology without disturbing existing lore.

--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg: #0b0b12; --ink: #e8e8f0; --muted: #a6a6c1; }
-    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding: 12px 16px; border-bottom: 1px solid #1d1d2a; }
-    .status { color: var(--muted); font-size: 12px; }
-    #stage { display: block; margin: 16px auto; box-shadow: 0 0 0 1px #1d1d2a; }
-    .note { max-width: 900px; margin: 0 auto 16px; color: var(--muted); }
-    code { background: #11111a; padding: 2px 4px; border-radius: 3px; }
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
 <body>
@@ -23,8 +23,7 @@
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice for Codex 144:99. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes the Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -39,9 +38,8 @@
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
       } catch (err) {
-        // Local fetch can fail under the file protocol; returning null enables the
-        // fallback palette so offline double-click stays calm and predictable.
-        // Offline-first ND-safety: browsers may block file:// fetch. Returning null triggers the fallback palette.
+        // Offline-first ND safety: browsers often block file:// fetch.
+        // Returning null triggers the calm fallback palette instead of failing noisily.
         return null;
       }
     }
@@ -55,21 +53,13 @@
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants anchor each geometry routine in the renderer.
-    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
-
-    // ND-safe rationale: no motion, high readability, calm palette, steady layer order.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
     const activePalette = palette || defaults.palette;
     statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines.
+    // Numerology constants keep each geometry layer tethered to the requested canon.
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
-    // ND-safe rationale: one synchronous render, calm tones, layered order preserved.
+    // ND-safe rationale: single synchronous render, calm palette, consistent layer order.
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:activePalette, NUM });
   </script>
 </body>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,60 +1,17 @@
 /*
   helix-renderer.mjs
-  Static offline renderer for layered sacred geometry in Codex 144:99.
+  ND-safe static renderer for layered sacred geometry.
 
   Layer order (furthest to nearest):
-    1. Vesica field (repeating vesica piscis grid)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci curve (static golden spiral polyline)
-    4. Double-helix lattice (two strands with steady crossbars)
-
-  ND-safe commitments:
-    - No animation or timers; every layer renders once.
-    - Calm contrast pulled from an ND-safe palette.
-    - Small, pure helpers so the geometry remains transparent to audit.
-    1. Vesica field
-    2. Tree-of-Life scaffold
-    3. Fibonacci curve
-    4. Double-helix lattice
+    1) Vesica field (intersecting circles form the grounding grid)
+    2) Tree-of-Life scaffold (ten sephirot nodes with twenty-two connective paths)
+    3) Fibonacci curve (logarithmic spiral polyline)
+    4) Double-helix lattice (twin strands with steady crossbars)
 
   ND-safe rationale:
-    - No animation; geometry renders once with calm contrast.
-    - Pure helper functions keep the symbolic layers easy to audit.
-    - Palette fallback avoids harsh failure states when data is absent.
-  Layer order (rendered back-to-front):
-    1. Vesica field (grounding grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (logarithmic spiral sampled calmly)
-    4. Double-helix lattice (paired strands with steady rungs)
-
-  ND-safe rationale:
-  Layer order (rendered back-to-front):
-    1. Vesica field (grounding grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (logarithmic spiral sampled calmly)
-    4. Double-helix lattice (paired strands with steady rungs)
-
-  ND-safe rationale:
-    - No animation or timed updates; everything paints once per call.
-    - Calm palette and line weights prevent harsh contrast or flicker.
-    - Small pure helpers keep intent transparent, protecting the lore.
-  Layers (furthest to nearest):
-    1. Vesica field (intersecting circles forming the grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (Golden Ratio spiral rendered once)
-    4. Double-helix lattice (twin strands with steady crossbars)
-
-  ND-safe rationale:
-  Layers (furthest to nearest):
-    1. Vesica field (intersecting circles forming the grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (Golden Ratio spiral rendered once)
-    4. Double-helix lattice (twin strands with steady crossbars)
-
-  ND-safe rationale:
-    - No animation or flashing; every function runs once per invocation.
-    - Calm contrast controlled by palette values so sensory load stays gentle.
-    - Pure helper functions make adaptation easy without breaking lore.
+    - No motion or timers; each layer renders once when invoked.
+    - Calm palette with readable contrast to avoid sensory overload.
+    - Small, pure helper functions keep the cosmology legible and lore-safe.
 */
 
 const DEFAULT_PALETTE = {
@@ -74,39 +31,10 @@ const DEFAULT_NUM = {
   ONEFORTYFOUR: 144
 };
 
-// Exported entry point. Accepts a 2d context, dimensions, palette, and numerology constants.
-export function renderHelix(ctx, opts = {}) {
+// Public entry point: orchestrates the four calm layers.
+export function renderHelix(ctx, config = {}) {
   if (!ctx) return;
-
-  const width = Number(opts.width) || 1440;
-  const height = Number(opts.height) || 900;
-  const safePalette = ensurePalette(opts.palette);
-  const safeNUM = ensureNumerology(opts.NUM);
-
-  fillBackground(ctx, width, height, safePalette.bg);
-  drawVesicaField(ctx, width, height, safePalette.layers[0], safeNUM);
-  drawTreeOfLife(ctx, width, height, safePalette.layers[1], safePalette.layers[2], safeNUM);
-  drawFibonacciCurve(ctx, width, height, safePalette.layers[3], safeNUM);
-  drawHelixLattice(ctx, width, height, safePalette.layers[4], safePalette.layers[5], safePalette.ink, safeNUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return { ...DEFAULT_PALETTE };
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  while (layers.length < 6) layers.push(DEFAULT_PALETTE.layers[layers.length]);
-
-// Exported entry point. Small pure function that orchestrates the four layers.
-export function renderHelix(ctx, options) {
-  if (!ctx || !options) return;
-  const settings = normalizeOptions(options);
-  const { width, height, palette, NUM } = settings;
-// Exported entry point. One pure orchestration pass maintains layer order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
-  const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumbers(opts.NUM);
+  const { width, height, palette, NUM } = normalizeOptions(config);
 
   fillBackground(ctx, width, height, palette.bg);
   drawVesicaField(ctx, width, height, palette.layers[0], NUM);
@@ -115,38 +43,42 @@ export function renderHelix(ctx, opts = {}) {
   drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
 }
 
-function normalizeOptions(options) {
-  const width = typeof options.width === "number" ? options.width : 1440;
-  const height = typeof options.height === "number" ? options.height : 900;
-  const palette = ensurePalette(options.palette);
-  const NUM = { ...DEFAULT_NUM, ...(options.NUM || {}) };
+function normalizeOptions(config) {
+  const width = Number.isFinite(config.width) ? config.width : 1440;
+  const height = Number.isFinite(config.height) ? config.height : 900;
+  const palette = ensurePalette(config.palette);
+  const NUM = ensureNumerology(config.NUM);
   return { width, height, palette, NUM };
 }
 
-// Validate palette input so missing data never breaks offline rendering.
-function ensurePalette(palette) {
-  if (!palette) return { ...DEFAULT_PALETTE };
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  while (layers.length < 6) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
-  }
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-// Validate palette input so missing data never disrupts offline rendering.
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
-  return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
+// Calm fallback palette keeps offline rendering predictable.
+function ensurePalette(input) {
+  if (!input) return { ...DEFAULT_PALETTE };
+  const safe = {
+    bg: typeof input.bg === "string" ? input.bg : DEFAULT_PALETTE.bg,
+    ink: typeof input.ink === "string" ? input.ink : DEFAULT_PALETTE.ink,
+    layers: []
   };
+  if (Array.isArray(input.layers)) {
+    for (let i = 0; i < Math.min(input.layers.length, DEFAULT_PALETTE.layers.length); i += 1) {
+      if (typeof input.layers[i] === "string") safe.layers.push(input.layers[i]);
+    }
+  }
+  while (safe.layers.length < DEFAULT_PALETTE.layers.length) {
+    safe.layers.push(DEFAULT_PALETTE.layers[safe.layers.length]);
+  }
+  return safe;
+}
+
+function ensureNumerology(rawNUM) {
+  const safe = { ...DEFAULT_NUM };
+  if (!rawNUM || typeof rawNUM !== "object") return safe;
+  for (const key of Object.keys(DEFAULT_NUM)) {
+    if (Number.isFinite(rawNUM[key])) {
+      safe[key] = rawNUM[key];
+    }
+  }
+  return safe;
 }
 
 function fillBackground(ctx, width, height, color) {
@@ -156,708 +88,198 @@ function fillBackground(ctx, width, height, color) {
   ctx.restore();
 }
 
-// Layer 1: Vesica field. Gentle grid keeps depth without motion.
-// Ensure numerology constants are available even if callers omit some keys.
-function ensureNumbers(NUM) {
-  const safe = { ...DEFAULT_NUM };
-  if (NUM) {
-    for (const key of Object.keys(DEFAULT_NUM)) {
-      if (Number.isFinite(NUM[key])) safe[key] = NUM[key];
-    }
-  }
-  return safe;
-}
-
-}
-
-// Ensure numerology constants are available even if callers omit some keys.
-function ensureNumbers(NUM) {
-  const safe = { ...DEFAULT_NUM };
-  if (NUM) {
-    for (const key of Object.keys(DEFAULT_NUM)) {
-      if (Number.isFinite(NUM[key])) safe[key] = NUM[key];
-    }
-  }
-  return safe;
-}
-
-// Layer 1: Vesica field. Static intersecting circles provide gentle grounding.
+// Layer 1: Vesica field - intersecting circles provide depth without motion.
 function drawVesicaField(ctx, width, height, color, NUM) {
+  const cols = NUM.NINE;
+  const rows = NUM.SEVEN;
+  const marginX = width / NUM.NINE;
+  const marginY = height / NUM.NINE;
+  const fieldWidth = width - marginX * 2;
+  const fieldHeight = height - marginY * 2;
+  const horizontalStep = fieldWidth / (cols - 1);
+  const verticalStep = fieldHeight / (rows - 1);
+  const radius = Math.min(horizontalStep, verticalStep) * 0.6;
 
-// Entry point: orchestrates the four layers in the requested order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
-  const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-
-// Entry point: orchestrates the four layers in the requested order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
-  const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-  fillBackground(ctx, width, height, palette.bg);
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
-  return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(num) {
-  const safe = { ...DEFAULT_NUM };
-  if (!num) return safe;
-  for (const key of Object.keys(safe)) {
-    const value = Number(num[key]);
-    if (Number.isFinite(value) && value !== 0) {
-      safe[key] = value;
-    }
-  }
-  return safe;
-function ensureNumerology(input) {
-  return { ...DEFAULT_NUM, ...(input || {}) };
-}
-
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-// Layer 1: Vesica field. Calm repetition anchors the scene without motion.
-function drawVesicaField(ctx, width, height, color, NUM) {
-// Layer 1: Vesica field — repeating circles for layered depth with no motion.
-export function drawVesica(ctx, width, height, color, NUM) {
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
+  ctx.lineWidth = 1.4;
+  ctx.globalAlpha = 0.28;
 
-  const radius = Math.min(width, height) / NUM.NINE;
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.NINE / NUM.ELEVEN);
-  const offset = radius / NUM.THREE;
-  const columns = NUM.SEVEN;
-  const offset = radius / NUM.THREE;
-<<  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  const startCol = -Math.floor(columns / 2);
-  const endCol = Math.floor(columns / 2);
-  const startRow = -Math.floor(rows / 2);
-  const endRow = Math.floor(rows / 2);
-
-  for (let row = startRow; row <= endRow; row++) {
-    for (let col = startCol; col <= endCol; col++) {
-      const cx = width / 2 + col * horizontalStep;
-      const cy = height / 2 + row * verticalStep;
-      drawVesicaPair(ctx, cx, cy, radius, offset);
-
+  for (let row = 0; row < rows; row += 1) {
+    const y = marginY + row * verticalStep;
+    const shift = (row % 2 === 0) ? 0 : horizontalStep / 2;
+    for (let col = 0; col < cols; col += 1) {
+      const x = marginX + shift + col * horizontalStep;
+      if (x < marginX * 0.5 || x > width - marginX * 0.5) continue;
       ctx.beginPath();
-      ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
+      ctx.ellipse(x, y, radius, radius, 0, 0, Math.PI * 2);
       ctx.stroke();
+    }
+  }
 
+  // Second pass: vertical vesica strands reinforce the lattice.
+  const verticalCols = NUM.SEVEN;
+  const verticalRows = NUM.NINE;
+  const verticalStepX = fieldWidth / (verticalCols - 1);
+  const verticalStepY = fieldHeight / (verticalRows - 1);
+  for (let col = 0; col < verticalCols; col += 1) {
+    const x = marginX + col * verticalStepX;
+    const shiftY = (col % 2 === 0) ? 0 : verticalStepY / 2;
+    for (let row = 0; row < verticalRows; row += 1) {
+      const y = marginY + shiftY + row * verticalStepY;
+      if (y < marginY * 0.5 || y > height - marginY * 0.5) continue;
       ctx.beginPath();
-      ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
+      ctx.ellipse(x, y, radius * 0.85, radius * 0.85, Math.PI / 2, 0, Math.PI * 2);
       ctx.stroke();
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.SEVEN / NUM.NINE);
-  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let r = -Math.floor(rows / 2); r <= Math.floor(rows / 2); r++) {
-    for (let c = -Math.floor(columns / 2); c <= Math.floor(columns / 2); c++) {
-      const cx = width / 2 + c * horizontalStep;
-      const cy = height / 2 + r * verticalStep;
-      drawCirclePair(ctx, cx, cy, radius, offset);
->>>>>>> main
     }
   }
 
   ctx.restore();
 }
 
-function drawVesicaPair(ctx, cx, cy, radius, offset) {
-<<// Layer 2: Tree-of-Life scaffold. Symmetric layout, no flashing.
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, NUM) {
-  const nodes = createTreeNodes(width, height, NUM);
-  const paths = createTreePaths();
-
-// Layer 2: Tree-of-Life scaffold with ten sephirot and twenty-two connective paths.
+// Layer 2: Tree-of-Life scaffold - ten sephirot nodes plus twenty-two connective paths.
 function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-function drawCirclePair(ctx, cx, cy, radius, offset) {
->>>>>>> main
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-// Layer 2: Tree-of-Life scaffold. Nodes glow softly; paths keep steady width.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
-  const verticalUnit = height / NUM.ONEFORTYFOUR;
+  const centerX = width / 2;
+  const marginY = height / NUM.NINE;
+  const verticalStep = (height - marginY * 2) / NUM.TWENTYTWO;
   const horizontalUnit = width / NUM.ELEVEN;
-  const centerX = width / 2;
+
+  const levelY = (multiplier) => marginY + multiplier * verticalStep;
+  const lane = (offset) => centerX + offset * horizontalUnit;
 
   const nodes = [
-    { x: centerX, y: verticalUnit * 9 },
-    { x: centerX + horizontalUnit, y: verticalUnit * 22 },
-    { x: centerX - horizontalUnit, y: verticalUnit * 22 },
-    { x: centerX + horizontalUnit * 1.4, y: verticalUnit * 44 },
-    { x: centerX - horizontalUnit * 1.4, y: verticalUnit * 44 },
-    { x: centerX, y: verticalUnit * 55 },
-    { x: centerX + horizontalUnit, y: verticalUnit * 77 },
-    { x: centerX - horizontalUnit, y: verticalUnit * 77 },
-    { x: centerX, y: verticalUnit * 99 },
-    { x: centerX, y: verticalUnit * 126 }
-
-// Layer 2: Tree-of-Life scaffold — static nodes and calm paths.
-export function drawTree(ctx, width, height, edgeColor, nodeColor, NUM) {
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
-
-<<<<  const columnSpacing = width / NUM.THIRTYTHREE;
-  const rowSpacing = (height / NUM.NINETYNINE) * NUM.NINE;
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const spread = width / NUM.ELEVEN;
-
-  const nodes = [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + spread, y: baseY * 22 },
-    { x: centerX - spread, y: baseY * 22 },
-    { x: centerX + spread * 1.4, y: baseY * 44 },
-    { x: centerX - spread * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + spread, y: baseY * 77 },
-    { x: centerX - spread, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
->>>>>>> main
+    { id: 0, x: lane(0), y: levelY(0) },
+    { id: 1, x: lane(1.8), y: levelY(NUM.THREE) },
+    { id: 2, x: lane(-1.8), y: levelY(NUM.THREE) },
+    { id: 3, x: lane(1.4), y: levelY(NUM.SEVEN) },
+    { id: 4, x: lane(-1.4), y: levelY(NUM.SEVEN) },
+    { id: 5, x: lane(0), y: levelY(NUM.ELEVEN) },
+    { id: 6, x: lane(1.4), y: levelY(NUM.ELEVEN + NUM.THREE) },
+    { id: 7, x: lane(-1.4), y: levelY(NUM.ELEVEN + NUM.THREE) },
+    { id: 8, x: lane(0), y: levelY(NUM.ELEVEN + NUM.SEVEN) },
+    { id: 9, x: lane(0), y: levelY(NUM.TWENTYTWO) }
   ];
 
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
   const paths = [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
+    [0, 1], [0, 2], [0, 5],
+    [1, 2], [1, 3], [1, 5],
+    [2, 4], [2, 5],
+    [3, 4], [3, 5], [3, 6],
+    [4, 5], [4, 7],
+    [5, 6], [5, 7], [5, 8],
+    [6, 7], [6, 8], [6, 9],
+    [7, 8], [7, 9],
+    [8, 9]
   ];
 
   ctx.save();
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
+  ctx.globalAlpha = 0.6;
+  for (const [a, b] of paths) {
+    const start = nodeById.get(a);
+    const end = nodeById.get(b);
+    if (!start || !end) continue;
     ctx.beginPath();
-    ctx.moveTo(nodes[a].x, nodes[a].y);
-    ctx.lineTo(nodes[b].x, nodes[b].y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
-  });
+  }
 
+  ctx.globalAlpha = 1;
   ctx.fillStyle = nodeColor;
-<<<<  const nodeRadius = Math.max(3, width / NUM.NINETYNINE);
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const radius = Math.max(3, width / NUM.NINETYNINE);
-  nodes.forEach(node => {
+  const nodeRadius = Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE;
+  for (const node of nodes) {
     ctx.beginPath();
-    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
-  });
-
+  }
   ctx.restore();
 }
 
-<<<<function createTreeNodes(width, height, NUM) {
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const horizontal = width / NUM.ELEVEN;
-  return [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + horizontal, y: baseY * 22 },
-    { x: centerX - horizontal, y: baseY * 22 },
-    { x: centerX + horizontal * 1.4, y: baseY * 44 },
-    { x: centerX - horizontal * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + horizontal, y: baseY * 77 },
-    { x: centerX - horizontal, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-}
-
-// Layer 3: Fibonacci curve. Static golden spiral with gentle sampling.
-// Layer 3: Fibonacci curve. Static spiral honours the Golden Ratio without motion.
+// Layer 3: Fibonacci curve - calm logarithmic spiral referencing golden ratio.
 function drawFibonacciCurve(ctx, width, height, color, NUM) {
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 3: Fibonacci curve — Golden Ratio spiral rendered once for calm focus.
-export function drawFibonacci(ctx, width, height, color, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const centerX = width * 0.32;
+  const centerY = height * 0.68;
+  const totalSteps = NUM.THIRTYTHREE;
+  const thetaMax = Math.PI * NUM.THREE; // three half-turns keep the curve gentle.
+  const growthRate = Math.log(phi) / (Math.PI / 2);
+  const baseRadius = Math.min(width, height) / NUM.NINETYNINE * NUM.THIRTYTHREE;
+
+  const points = [];
+  for (let i = 0; i <= totalSteps; i += 1) {
+    const t = i / totalSteps;
+    const theta = t * thetaMax;
+    const radius = baseRadius * Math.exp(growthRate * theta);
+    const x = centerX + Math.cos(theta) * radius;
+    const y = centerY + Math.sin(theta) * radius;
+    points.push({ x, y });
+  }
+
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-
-<<<<<<  // Golden Ratio constant keeps the spiral grounded in sacred proportion.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps sacred proportion stable.
-  const centerX = width / NUM.THREE * 2;
-  const centerY = height / NUM.THREE;
-  const scale = Math.min(width, height) / NUM.NINETYNINE;
-  const maxTheta = Math.PI * NUM.SEVEN;
-  const thetaStep = Math.PI / NUM.THIRTYTHREE;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= maxTheta; theta += thetaStep) {
-<<<<<<    const radius = scale * Math.pow(golden, theta / (Math.PI / 2));
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio constant keeps the growth soothing.
-  const center = {
-    x: (width / NUM.THREE) * 2,
-    y: height / NUM.THREE
-  };
-  const turns = NUM.THREE;
-  const scale = (Math.min(width, height) / NUM.NINETYNINE) * NUM.SEVEN;
-  const step = Math.PI / NUM.TWENTYTWO;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= Math.PI * 2 * turns; theta += step) {
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
+  ctx.lineWidth = 3;
+  ctx.globalAlpha = 0.75;
+  strokePolyline(ctx, points);
   ctx.restore();
 }
 
-<<<<<<// Layer 4: Double-helix lattice. Static strands avoid motion triggers.
-// Layer 4: Double-helix lattice with calm strands and steady crossbars.
-function drawHelixLattice(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 4: Double-helix lattice — static strands with crossbars, zero motion.
-export function drawHelix(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
-  ctx.save();
+// Layer 4: Double-helix lattice - two static strands with steady crossbars.
+function drawHelixLattice(ctx, width, height, strandAColor, strandBColor, rungColor, NUM) {
+  const steps = NUM.NINETYNINE;
+  const rotations = NUM.THREE; // three gentle twists.
+  const marginY = height / NUM.NINE;
+  const spanY = height - marginY * 2;
+  const midX = width * 0.68;
+  const amplitude = width / NUM.ELEVEN;
 
-  const steps = NUM.TWENTYTWO;
-  const amplitude = height / NUM.THIRTYTHREE;
-  const frequency = (Math.PI * NUM.ELEVEN) / width;
-  const baseline = height * 0.65;
-
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, 0, strandColorA);
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, Math.PI, strandColorB || strandColorA);
->>>>>>>+codex/add-codeb
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor);
-
-  ctx.restore();
-}
-
-function drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, phase, color) {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y = baseline + amplitude * Math.sin(frequency * x + phase);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
+  const strandA = [];
+  const strandB = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const y = marginY + t * spanY;
+    const phase = t * Math.PI * rotations;
+    const offset = Math.sin(phase) * amplitude;
+    strandA.push({ x: midX - offset, y });
+    strandB.push({ x: midX + offset, y });
   }
-  ctx.stroke();
-}
 
-function drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, color) {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y2 = baseline + amplitude * Math.sin(frequency * x + Math.PI);
-    // Static crossbars maintain the double-helix lattice without introducing motion.
->>>>>>>+codex/add-codeb
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const yA = baseline + amplitude * Math.sin(frequency * x);
-    const yB = baseline + amplitude * Math.sin(frequency * x + Math.PI);
+  ctx.save();
+  ctx.lineWidth = 2.4;
+  ctx.globalAlpha = 0.85;
+  ctx.strokeStyle = strandAColor;
+  strokePolyline(ctx, strandA);
+  ctx.strokeStyle = strandBColor;
+  strokePolyline(ctx, strandB);
+
+  // Crossbars anchor the strands; count references twenty-two paths.
+  ctx.strokeStyle = rungColor;
+  ctx.lineWidth = 1.6;
+  ctx.globalAlpha = 0.5;
+  const rungCount = NUM.TWENTYTWO;
+  for (let i = 0; i <= rungCount; i += 1) {
+    const t = i / rungCount;
+    const y = marginY + t * spanY;
+    const phase = t * Math.PI * rotations;
+    const offset = Math.sin(phase) * amplitude;
     ctx.beginPath();
-    ctx.moveTo(x, yA);
-    ctx.lineTo(x, yB);
-    ctx.stroke();
-  }
-}
-  fillBackground(ctx, width, height, palette.bg);
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
-  return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(input) {
-  return { ...DEFAULT_NUM, ...(input || {}) };
-}
-
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-// Layer 1: Vesica field — repeating circles for layered depth with no motion.
-export function drawVesica(ctx, width, height, color, NUM) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
-
-  const radius = Math.min(width, height) / NUM.NINE;
-  const offset = radius / NUM.THREE;
-<<  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let row = -Math.floor(rows / 2); row <= Math.floor(rows / 2); row++) {
-    for (let col = -Math.floor(columns / 2); col <= Math.floor(columns / 2); col++) {
-      const cx = width / 2 + col * horizontalStep;
-      const cy = height / 2 + row * verticalStep;
-
-      ctx.beginPath();
-      ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
-
-      ctx.beginPath();
-      ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
->>>>>>>+codex/add-codeb
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.SEVEN / NUM.NINE);
-  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let r = -Math.floor(rows / 2); r <= Math.floor(rows / 2); r++) {
-    for (let c = -Math.floor(columns / 2); c <= Math.floor(columns / 2); c++) {
-      const cx = width / 2 + c * horizontalStep;
-      const cy = height / 2 + r * verticalStep;
-      drawCirclePair(ctx, cx, cy, radius, offset);
-    }
-  }
-
-  ctx.restore();
-}
-
-<<// Layer 2: Tree-of-Life scaffold. Symmetric layout, no flashing.
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, NUM) {
-  const nodes = createTreeNodes(width, height, NUM);
-  const paths = createTreePaths();
-
-// Layer 2: Tree-of-Life scaffold with ten sephirot and twenty-two connective paths.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
->>>>>>>+codex/add-codeb
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-function drawCirclePair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-// Layer 2: Tree-of-Life scaffold — static nodes and calm paths.
-export function drawTree(ctx, width, height, edgeColor, nodeColor, NUM) {
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
-
-<<<<  const columnSpacing = width / NUM.THIRTYTHREE;
-  const rowSpacing = (height / NUM.NINETYNINE) * NUM.NINE;
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const spread = width / NUM.ELEVEN;
-
-  const nodes = [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + spread, y: baseY * 22 },
-    { x: centerX - spread, y: baseY * 22 },
-    { x: centerX + spread * 1.4, y: baseY * 44 },
-    { x: centerX - spread * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + spread, y: baseY * 77 },
-    { x: centerX - spread, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-
-  const paths = [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-
->>>>>>> main
-  paths.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a].x, nodes[a].y);
-    ctx.lineTo(nodes[b].x, nodes[b].y);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-<<<<  const nodeRadius = Math.max(3, width / NUM.NINETYNINE);
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const radius = Math.max(3, width / NUM.NINETYNINE);
-  nodes.forEach(node => {
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-  });
-
-  ctx.restore();
-}
-
-<<<<<<< codex/update-registry-for-numbers-0-144
-// Layer 3: Fibonacci curve. Static golden spiral expresses growth without motion.
-<<<<function createTreeNodes(width, height, NUM) {
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const horizontal = width / NUM.ELEVEN;
-  return [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + horizontal, y: baseY * 22 },
-    { x: centerX - horizontal, y: baseY * 22 },
-    { x: centerX + horizontal * 1.4, y: baseY * 44 },
-    { x: centerX - horizontal * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + horizontal, y: baseY * 77 },
-    { x: centerX - horizontal, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-}
-
-// Layer 3: Fibonacci curve. Static golden spiral with gentle sampling.
-// Layer 3: Fibonacci curve. Static spiral honours the Golden Ratio without motion.
-function drawFibonacciCurve(ctx, width, height, color, NUM) {
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 3: Fibonacci curve — Golden Ratio spiral rendered once for calm focus.
-export function drawFibonacci(ctx, width, height, color, NUM) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-
-  // Golden Ratio ensures the spiral honours lineage growth while remaining static.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
-  const baseScale = Math.min(width, height) / NUM.NINETYNINE * NUM.SEVEN;
-<<<<<<  // Golden Ratio constant keeps the spiral grounded in sacred proportion.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps sacred proportion stable.
-  const centerX = width / NUM.THREE * 2;
-  const centerY = height / NUM.THREE;
-  const scale = Math.min(width, height) / NUM.NINETYNINE;
->>>>>>> main
-  const maxTheta = Math.PI * NUM.SEVEN;
-  const thetaStep = Math.PI / NUM.THIRTYTHREE;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= maxTheta; theta += thetaStep) {
-    const radius = baseScale * Math.pow(golden, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-<<<<<<    const radius = scale * Math.pow(golden, theta / (Math.PI / 2));
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio constant keeps the growth soothing.
-  const center = {
-    x: (width / NUM.THREE) * 2,
-    y: height / NUM.THREE
-  };
-  const turns = NUM.THREE;
-  const scale = (Math.min(width, height) / NUM.NINETYNINE) * NUM.SEVEN;
-  const step = Math.PI / NUM.TWENTYTWO;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= Math.PI * 2 * turns; theta += step) {
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
->>>>>>> main
-  }
-  ctx.stroke();
-
-  ctx.restore();
-}
-
-// Layer 4: Double-helix lattice. Static strands echo DNA symbolism without animation.
-<<<<<<// Layer 4: Double-helix lattice. Static strands avoid motion triggers.
-// Layer 4: Double-helix lattice with calm strands and steady crossbars.
-function drawHelixLattice(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 4: Double-helix lattice — static strands with crossbars, zero motion.
-export function drawHelix(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
-  ctx.save();
-
-  const steps = NUM.TWENTYTWO;
-  const amplitude = height / NUM.THIRTYTHREE;
-  const frequency = (Math.PI * NUM.ELEVEN) / width;
-  const baseline = height * 0.65;
-
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, 0, strandColorA);
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, Math.PI, strandColorB || strandColorA);
-<<<<<<<   drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor || strandColorA);
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
->>>>>>> main
-  drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor);
-
-  ctx.restore();
-}
-
-function drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, phase, color) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y = baseline + amplitude * Math.sin(frequency * x + phase);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-  ctx.restore();
-}
-
-function drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, color) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y2 = baseline + amplitude * Math.sin(frequency * x + Math.PI);
-<<<<<<< codex/update-registry-for-numbers-0-144
-    // Static crossbars maintain the double-helix lattice without introducing motion.
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const yA = baseline + amplitude * Math.sin(frequency * x);
-    const yB = baseline + amplitude * Math.sin(frequency * x + Math.PI);
->>>>>>> main
-    ctx.beginPath();
-    ctx.moveTo(x, yA);
-    ctx.lineTo(x, yB);
+    ctx.moveTo(midX - offset, y);
+    ctx.lineTo(midX + offset, y);
     ctx.stroke();
   }
   ctx.restore();
+}
+
+// Shared helper: stroke a sequence of points without animation.
+function strokePolyline(ctx, points) {
+  if (!points.length) return;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.stroke();
 }


### PR DESCRIPTION
## Summary
- streamline the offline index entry point with fallback palette loading and ND-safe status messaging
- rebuild the helix renderer module with pure helpers for the vesica grid, tree-of-life, fibonacci curve, and double helix layers
- refresh the renderer README with concise file descriptions, ND-safe design notes, and local usage guidance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cde2e1fe108328aa47020941282d97