### PR TITLE
Rebuild offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -16,97 +16,13 @@ Static offline canvas renderer for layered sacred geometry in Codex 144:99. Doub
 ## ND-safe Design
 - No motion, autoplay, or flashing effects; each layer renders once for sensory calm.
 - Palette loads from `data/palette.json`; when unavailable the fallback palette renders and a notice appears in the header.
-- Colors and spacing maintain readable contrast while referencing numerology constants 3, 7, 9, 11, 22, 33, 99, and 144.
+- Colors and spacing reference numerology constants 3, 7, 9, 11, 22, 33, 99, and 144 to keep symbolism traceable.
 - Pure drawing helpers keep the geometry transparent so adaptations do not disturb existing lore.
 
 ## Local Use
-1. Keep the three files in their current folders.
+1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
 2. Optionally adjust `data/palette.json` to fit lineage palettes while honoring WCAG AA contrast.
 3. Open `index.html` directly (double-click). Modern Chromium, Firefox, and WebKit builds render the scene offline.
-4. If the browser blocks file fetches, the fallback palette ensures the canvas still renders safely.
+4. If the browser blocks file fetches, the fallback palette ensures the canvas still renders safely and the status note reports the mode.
 
-This renderer is intentionally lightweight: no workflows, no dependencies, and no background services. Geometry is calculated on demand by small pure functions so the layered cosmology stays legible and trauma-informed.
-Static offline HTML5 canvas renderer for the layered cosmology in Codex 144:99. Double-click `index.html` in any modern browser; no server or network access is required.
-
-## Files
-- `index.html` - entry document with 1440x900 canvas, palette loader, and fallback status note.
-- `js/helix-renderer.mjs` - ES module exposing `renderHelix` plus pure helpers for each geometric layer.
-- `data/palette.json` - optional ND-safe palette override (background, ink, and six layer hues).
-- `README_RENDERER.md` - this usage and safety guide.
-
-## Layered Output
-1. **Vesica field** - repeating vesica grid grounds the composition.
-2. **Tree-of-Life scaffold** - ten nodes and twenty-two paths mapped with numerology spacing.
-3. **Fibonacci curve** - static golden spiral drawn with gentle sampling (no animation).
-4. **Double-helix lattice** - two phase-shifted strands plus steady rungs to preserve depth.
-
-## ND-safe Design Choices
-- No motion, autoplay, or flashing effects; geometry renders once on load.
-- Calm palette with readable contrast; fallback palette prevents blank screens if data is missing.
-- Helper functions are small and pure so adjustments stay reversible and lore-safe.
-- Geometry parameters derive from sacred numerology constants (3, 7, 9, 11, 22, 33, 99, 144) for traceable symbolism.
-
-## Local Use
-1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
-2. Optionally adjust `data/palette.json` to suit your lighting conditions (six layer colors are expected).
-3. Open `index.html` directly (double-click). Modern browsers such as Firefox or Chromium-based builds render without additional steps.
-4. If palette loading fails due to local file sandboxing, the built-in fallback palette renders and the header reports the safe state.
-
-This renderer is intentionally lightweight: no bundlers, no workflows, and no external dependencies. All geometry is calculated on demand by pure functions to honor the cathedral protocol.
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Open `index.html` directly in any modern browser; no server, workflow, or network call is required.
-
-## Files
-Static offline canvas renderer for layered sacred geometry in Codex 144:99. Open `index.html` directly in any modern browser; no server, workflow, or network call is required.
-
-## Files
-- `index.html` - Entry point with 1440x900 canvas, status notice, and palette fallback logic.
-- `js/helix-renderer.mjs` - ES module that draws the four layers using small pure helpers.
-- `data/palette.json` - Optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-1. **Vesica field** - Nine intersecting circles form the grounding grid.
-2. **Tree-of-Life scaffold** - Ten nodes and twenty-two paths plotted with numerology spacing.
-3. **Fibonacci curve** - Static golden spiral using calm sampling (no animation).
-4. **Double-helix lattice** - Two phase-shifted strands plus steady rungs for depth.
-
-## ND-safe Design Notes
-- No motion, autoplay, or flashing effects; everything renders once when the page loads.
-- Palette loads from local data; if `data/palette.json` is missing, a safe fallback palette renders and a notice appears in the header.
-- Colors and spacing follow a trauma-informed hierarchy to support gentle contrast.
-- Geometry parameters derive from numerology constants 3, 7, 9, 11, 22, 33, 99, and 144 to honor the cosmology.
-
-## Local Use
-1. Keep the three files in the same relative folders.
-2. Optionally adjust `data/palette.json` to match your desired calm palette.
-3. Double-click `index.html`. Modern browsers such as Firefox or Chromium-based builds render it offline without extra steps.
-4. If palette loading fails because of local file sandbox rules, the fallback palette still renders and the status note confirms the safe mode.
-
-All geometry code is heavily commented so future integrations can extend the lattice without disturbing existing lore.
-- `index.html` — entry document with a 1440x900 canvas, palette loader, and fallback notice.
-- `js/helix-renderer.mjs` — ES module exposing `renderHelix` plus pure helpers for each layer.
-- `data/palette.json` — optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-- `index.html` — entry document with a 1440x900 canvas, palette loader, and fallback notice.
-- `js/helix-renderer.mjs` — ES module exposing `renderHelix` plus pure helpers for each layer.
-- `data/palette.json` — optional ND-safe palette override (background, ink, and six layer hues).
-
-## Rendered Layers
-1. **Vesica field** — intersecting circles establish the base grid and depth.
-2. **Tree-of-Life scaffold** — ten sephirot and twenty-two paths mapped to numerology constants.
-3. **Fibonacci curve** — static Golden Ratio spiral sampled gently for calm focus.
-4. **Double-helix lattice** — two phase-shifted strands with crossbars to preserve layered geometry.
-
-## ND-safe Design Notes
-- No motion, autoplay, or flashing effects; the scene renders once on load.
-- Palette loads locally; if `data/palette.json` is missing or blocked, a built-in fallback palette renders and the header displays a notice.
-- Colors follow a calm contrast hierarchy to support trauma-informed use.
-- Geometry parameters derive from sacred numerology constants (3, 7, 9, 11, 22, 33, 99, 144) for traceable symbolism.
-
-## Local Use
-1. Keep the three files in their existing folders.
-2. Optionally adjust `data/palette.json` with six layer hues that meet your contrast needs.
-3. Open `index.html` directly (double-click). Modern browsers such as Firefox or Chromium-based builds render without additional steps.
-4. If palette loading fails due to local file sandboxing, the fallback palette still renders safely.
-
-This renderer stays intentionally lightweight: no bundlers, no dependencies, and no workflows. All geometry is calculated by small pure functions to honour the project's layered cosmology without disturbing existing lore.
+This renderer stays intentionally lightweight: no workflows, no dependencies, and no background services. Geometry is calculated on demand by small pure functions so the layered cosmology remains legible and trauma-informed.

--- a/index.html
+++ b/index.html
@@ -6,30 +6,29 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg: #0b0b12; --ink: #e8e8f0; --muted: #a6a6c1; }
-    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding: 12px 16px; border-bottom: 1px solid #1d1d2a; }
-    .status { color: var(--muted); font-size: 12px; }
-    #stage { display: block; margin: 16px auto; box-shadow: 0 0 0 1px #1d1d2a; }
-    .note { max-width: 900px; margin: 0 auto 16px; color: var(--muted); }
-    code { background: #11111a; padding: 2px 4px; border-radius: 3px; }
+    /* ND-safe: calm contrast, no motion, gentle spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice for Codex 144:99. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, and no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
@@ -39,9 +38,7 @@
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
       } catch (err) {
-        // Local fetch can fail under the file protocol; returning null enables the
-        // fallback palette so offline double-click stays calm and predictable.
-        // Offline-first ND-safety: browsers may block file:// fetch. Returning null triggers the fallback palette.
+        // Offline-first ND-safe design: browsers may block file:// fetch, so fall back calmly.
         return null;
       }
     }
@@ -55,22 +52,14 @@
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants anchor each geometry routine in the renderer.
-    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
-
-    // ND-safe rationale: no motion, high readability, calm palette, steady layer order.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
     const activePalette = palette || defaults.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines.
+    // Numerology constants: every layer references these sacred values.
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
-    // ND-safe rationale: one synchronous render, calm tones, layered order preserved.
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:activePalette, NUM });
+    // Single synchronous render keeps the scene stable and ND-safe.
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,60 +1,16 @@
 /*
   helix-renderer.mjs
-  Static offline renderer for layered sacred geometry in Codex 144:99.
+  ND-safe static renderer for the layered cosmology in Codex 144:99.
 
   Layer order (furthest to nearest):
-    1. Vesica field (repeating vesica piscis grid)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
+    1. Vesica field (intersecting circles to ground the scene)
+    2. Tree-of-Life scaffold (ten sephirot connected by twenty-two paths)
     3. Fibonacci curve (static golden spiral polyline)
-    4. Double-helix lattice (two strands with steady crossbars)
+    4. Double-helix lattice (paired strands with steady crossbars)
 
-  ND-safe commitments:
-    - No animation or timers; every layer renders once.
-    - Calm contrast pulled from an ND-safe palette.
-    - Small, pure helpers so the geometry remains transparent to audit.
-    1. Vesica field
-    2. Tree-of-Life scaffold
-    3. Fibonacci curve
-    4. Double-helix lattice
-
-  ND-safe rationale:
-    - No animation; geometry renders once with calm contrast.
-    - Pure helper functions keep the symbolic layers easy to audit.
-    - Palette fallback avoids harsh failure states when data is absent.
-  Layer order (rendered back-to-front):
-    1. Vesica field (grounding grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (logarithmic spiral sampled calmly)
-    4. Double-helix lattice (paired strands with steady rungs)
-
-  ND-safe rationale:
-  Layer order (rendered back-to-front):
-    1. Vesica field (grounding grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (logarithmic spiral sampled calmly)
-    4. Double-helix lattice (paired strands with steady rungs)
-
-  ND-safe rationale:
-    - No animation or timed updates; everything paints once per call.
-    - Calm palette and line weights prevent harsh contrast or flicker.
-    - Small pure helpers keep intent transparent, protecting the lore.
-  Layers (furthest to nearest):
-    1. Vesica field (intersecting circles forming the grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (Golden Ratio spiral rendered once)
-    4. Double-helix lattice (twin strands with steady crossbars)
-
-  ND-safe rationale:
-  Layers (furthest to nearest):
-    1. Vesica field (intersecting circles forming the grid)
-    2. Tree-of-Life scaffold (ten nodes, twenty-two connective paths)
-    3. Fibonacci curve (Golden Ratio spiral rendered once)
-    4. Double-helix lattice (twin strands with steady crossbars)
-
-  ND-safe rationale:
-    - No animation or flashing; every function runs once per invocation.
-    - Calm contrast controlled by palette values so sensory load stays gentle.
-    - Pure helper functions make adaptation easy without breaking lore.
+  All helpers are small pure functions and run once per render call.
+  This honors the offline-first, trauma-informed protocol: no motion,
+  gentle contrast, and clear layering comments explaining why.
 */
 
 const DEFAULT_PALETTE = {
@@ -74,93 +30,43 @@ const DEFAULT_NUM = {
   ONEFORTYFOUR: 144
 };
 
-// Exported entry point. Accepts a 2d context, dimensions, palette, and numerology constants.
+// Entry point: orchestrates the four layers in a single synchronous pass.
 export function renderHelix(ctx, opts = {}) {
   if (!ctx) return;
 
-  const width = Number(opts.width) || 1440;
-  const height = Number(opts.height) || 900;
-  const safePalette = ensurePalette(opts.palette);
-  const safeNUM = ensureNumerology(opts.NUM);
-
-  fillBackground(ctx, width, height, safePalette.bg);
-  drawVesicaField(ctx, width, height, safePalette.layers[0], safeNUM);
-  drawTreeOfLife(ctx, width, height, safePalette.layers[1], safePalette.layers[2], safeNUM);
-  drawFibonacciCurve(ctx, width, height, safePalette.layers[3], safeNUM);
-  drawHelixLattice(ctx, width, height, safePalette.layers[4], safePalette.layers[5], safePalette.ink, safeNUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return { ...DEFAULT_PALETTE };
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  while (layers.length < 6) layers.push(DEFAULT_PALETTE.layers[layers.length]);
-
-// Exported entry point. Small pure function that orchestrates the four layers.
-export function renderHelix(ctx, options) {
-  if (!ctx || !options) return;
-  const settings = normalizeOptions(options);
-  const { width, height, palette, NUM } = settings;
-// Exported entry point. One pure orchestration pass maintains layer order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
+  const width = typeof opts.width === "number" ? opts.width : 1440;
+  const height = typeof opts.height === "number" ? opts.height : 900;
   const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumbers(opts.NUM);
+  const NUM = ensureNumerology(opts.NUM);
 
   fillBackground(ctx, width, height, palette.bg);
   drawVesicaField(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], palette.ink, NUM);
   drawFibonacciCurve(ctx, width, height, palette.layers[3], NUM);
   drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
 }
 
-function normalizeOptions(options) {
-  const width = typeof options.width === "number" ? options.width : 1440;
-  const height = typeof options.height === "number" ? options.height : 900;
-  const palette = ensurePalette(options.palette);
-  const NUM = { ...DEFAULT_NUM, ...(options.NUM || {}) };
-  return { width, height, palette, NUM };
-}
-
-// Validate palette input so missing data never breaks offline rendering.
+// Validate palette input so missing data never blocks offline rendering.
 function ensurePalette(palette) {
-  if (!palette) return { ...DEFAULT_PALETTE };
+  const base = { ...DEFAULT_PALETTE };
+  if (!palette) return base;
+
   const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
   while (layers.length < 6) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
+    layers.push(base.layers[layers.length]);
   }
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
 
-// Validate palette input so missing data never disrupts offline rendering.
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
   return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
+    bg: typeof palette.bg === "string" ? palette.bg : base.bg,
+    ink: typeof palette.ink === "string" ? palette.ink : base.ink,
     layers
   };
 }
 
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-// Layer 1: Vesica field. Gentle grid keeps depth without motion.
-// Ensure numerology constants are available even if callers omit some keys.
-function ensureNumbers(NUM) {
+// Ensure numerology constants exist so geometry math stays predictable.
+function ensureNumerology(NUM) {
   const safe = { ...DEFAULT_NUM };
-  if (NUM) {
+  if (NUM && typeof NUM === "object") {
     for (const key of Object.keys(DEFAULT_NUM)) {
       if (Number.isFinite(NUM[key])) safe[key] = NUM[key];
     }
@@ -168,71 +74,6 @@ function ensureNumbers(NUM) {
   return safe;
 }
 
-}
-
-// Ensure numerology constants are available even if callers omit some keys.
-function ensureNumbers(NUM) {
-  const safe = { ...DEFAULT_NUM };
-  if (NUM) {
-    for (const key of Object.keys(DEFAULT_NUM)) {
-      if (Number.isFinite(NUM[key])) safe[key] = NUM[key];
-    }
-  }
-  return safe;
-}
-
-// Layer 1: Vesica field. Static intersecting circles provide gentle grounding.
-function drawVesicaField(ctx, width, height, color, NUM) {
-
-// Entry point: orchestrates the four layers in the requested order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
-  const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-
-// Entry point: orchestrates the four layers in the requested order.
-export function renderHelix(ctx, opts = {}) {
-  if (!ctx) return;
-  const width = opts.width || 1440;
-  const height = opts.height || 900;
-  const palette = ensurePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-  fillBackground(ctx, width, height, palette.bg);
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
-  return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(num) {
-  const safe = { ...DEFAULT_NUM };
-  if (!num) return safe;
-  for (const key of Object.keys(safe)) {
-    const value = Number(num[key]);
-    if (Number.isFinite(value) && value !== 0) {
-      safe[key] = value;
-    }
-  }
-  return safe;
-function ensureNumerology(input) {
-  return { ...DEFAULT_NUM, ...(input || {}) };
-}
-
 function fillBackground(ctx, width, height, color) {
   ctx.save();
   ctx.fillStyle = color;
@@ -240,624 +81,185 @@ function fillBackground(ctx, width, height, color) {
   ctx.restore();
 }
 
-// Layer 1: Vesica field. Calm repetition anchors the scene without motion.
+// Layer 1: Vesica field. Intersecting circles provide depth without motion.
 function drawVesicaField(ctx, width, height, color, NUM) {
-// Layer 1: Vesica field — repeating circles for layered depth with no motion.
-export function drawVesica(ctx, width, height, color, NUM) {
+  const cols = Math.max(1, NUM.NINE);
+  const rows = Math.max(1, NUM.SEVEN);
+  const stepX = width / (cols + 1);
+  const stepY = height / (rows + 1);
+  const radius = Math.min(stepX, stepY) * 0.75;
+  const offset = radius / NUM.THREE;
+
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
+  ctx.globalAlpha = 0.25;
+  ctx.lineWidth = Math.max(1, Math.min(width, height) / NUM.NINETYNINE);
 
-  const radius = Math.min(width, height) / NUM.NINE;
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.NINE / NUM.ELEVEN);
-  const offset = radius / NUM.THREE;
-  const columns = NUM.SEVEN;
-  const offset = radius / NUM.THREE;
-<<  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  const startCol = -Math.floor(columns / 2);
-  const endCol = Math.floor(columns / 2);
-  const startRow = -Math.floor(rows / 2);
-  const endRow = Math.floor(rows / 2);
-
-  for (let row = startRow; row <= endRow; row++) {
-    for (let col = startCol; col <= endCol; col++) {
-      const cx = width / 2 + col * horizontalStep;
-      const cy = height / 2 + row * verticalStep;
-      drawVesicaPair(ctx, cx, cy, radius, offset);
-
-      ctx.beginPath();
-      ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
-
-      ctx.beginPath();
-      ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.SEVEN / NUM.NINE);
-  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let r = -Math.floor(rows / 2); r <= Math.floor(rows / 2); r++) {
-    for (let c = -Math.floor(columns / 2); c <= Math.floor(columns / 2); c++) {
-      const cx = width / 2 + c * horizontalStep;
-      const cy = height / 2 + r * verticalStep;
-      drawCirclePair(ctx, cx, cy, radius, offset);
->>>>>>> main
+  for (let row = 1; row <= rows; row++) {
+    const cy = stepY * row;
+    for (let col = 1; col <= cols; col++) {
+      const cx = stepX * col;
+      drawCircle(ctx, cx - offset, cy, radius);
+      drawCircle(ctx, cx + offset, cy, radius);
     }
   }
 
   ctx.restore();
 }
 
-function drawVesicaPair(ctx, cx, cy, radius, offset) {
-<<// Layer 2: Tree-of-Life scaffold. Symmetric layout, no flashing.
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, NUM) {
-  const nodes = createTreeNodes(width, height, NUM);
-  const paths = createTreePaths();
-
-// Layer 2: Tree-of-Life scaffold with ten sephirot and twenty-two connective paths.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-function drawCirclePair(ctx, cx, cy, radius, offset) {
->>>>>>> main
+function drawCircle(ctx, cx, cy, radius) {
   ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
   ctx.stroke();
 }
 
-// Layer 2: Tree-of-Life scaffold. Nodes glow softly; paths keep steady width.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
-  const verticalUnit = height / NUM.ONEFORTYFOUR;
-  const horizontalUnit = width / NUM.ELEVEN;
+// Layer 2: Tree-of-Life scaffold. Ten nodes, twenty-two calm connective paths.
+function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, ink, NUM) {
+  const unitY = height / NUM.ONEFORTYFOUR;
+  const unitX = width / NUM.ONEFORTYFOUR;
   const centerX = width / 2;
 
+  // Positions derive from numerology units to honor the cosmology.
   const nodes = [
-    { x: centerX, y: verticalUnit * 9 },
-    { x: centerX + horizontalUnit, y: verticalUnit * 22 },
-    { x: centerX - horizontalUnit, y: verticalUnit * 22 },
-    { x: centerX + horizontalUnit * 1.4, y: verticalUnit * 44 },
-    { x: centerX - horizontalUnit * 1.4, y: verticalUnit * 44 },
-    { x: centerX, y: verticalUnit * 55 },
-    { x: centerX + horizontalUnit, y: verticalUnit * 77 },
-    { x: centerX - horizontalUnit, y: verticalUnit * 77 },
-    { x: centerX, y: verticalUnit * 99 },
-    { x: centerX, y: verticalUnit * 126 }
-
-// Layer 2: Tree-of-Life scaffold — static nodes and calm paths.
-export function drawTree(ctx, width, height, edgeColor, nodeColor, NUM) {
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
-
-<<<<  const columnSpacing = width / NUM.THIRTYTHREE;
-  const rowSpacing = (height / NUM.NINETYNINE) * NUM.NINE;
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const spread = width / NUM.ELEVEN;
-
-  const nodes = [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + spread, y: baseY * 22 },
-    { x: centerX - spread, y: baseY * 22 },
-    { x: centerX + spread * 1.4, y: baseY * 44 },
-    { x: centerX - spread * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + spread, y: baseY * 77 },
-    { x: centerX - spread, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
->>>>>>> main
+    { name: "kether", x: centerX, y: unitY * NUM.NINE },
+    { name: "chokmah", x: centerX + unitX * NUM.TWENTYTWO, y: unitY * NUM.TWENTYTWO },
+    { name: "binah", x: centerX - unitX * NUM.TWENTYTWO, y: unitY * NUM.TWENTYTWO },
+    { name: "chesed", x: centerX + unitX * (NUM.THIRTYTHREE - NUM.THREE), y: unitY * (NUM.THIRTYTHREE + NUM.THREE) },
+    { name: "geburah", x: centerX - unitX * (NUM.THIRTYTHREE - NUM.THREE), y: unitY * (NUM.THIRTYTHREE + NUM.THREE) },
+    { name: "tiphereth", x: centerX, y: unitY * (NUM.ONEFORTYFOUR / 2) },
+    { name: "netzach", x: centerX + unitX * NUM.TWENTYTWO, y: unitY * NUM.NINETYNINE },
+    { name: "hod", x: centerX - unitX * NUM.TWENTYTWO, y: unitY * NUM.NINETYNINE },
+    { name: "yesod", x: centerX, y: unitY * (NUM.NINETYNINE + NUM.ELEVEN) },
+    { name: "malkuth", x: centerX, y: unitY * (NUM.ONEFORTYFOUR - NUM.ELEVEN) }
   ];
 
   const paths = [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
+    [0, 1], [0, 2], [0, 5],
+    [1, 2], [1, 3], [1, 5], [1, 6],
+    [2, 4], [2, 5], [2, 7],
+    [3, 4], [3, 5], [3, 6],
+    [4, 5], [4, 7],
+    [5, 6], [5, 7], [5, 8],
+    [6, 8], [7, 8],
+    [7, 9], [8, 9]
   ];
 
   ctx.save();
   ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
+  ctx.globalAlpha = 0.45;
+  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / (NUM.ONEFORTYFOUR / 2));
+
+  for (const [a, b] of paths) {
+    const start = nodes[a];
+    const end = nodes[b];
     ctx.beginPath();
-    ctx.moveTo(nodes[a].x, nodes[a].y);
-    ctx.lineTo(nodes[b].x, nodes[b].y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-<<<<  const nodeRadius = Math.max(3, width / NUM.NINETYNINE);
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const radius = Math.max(3, width / NUM.NINETYNINE);
-  nodes.forEach(node => {
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-  });
-
-  ctx.restore();
-}
-
-<<<<function createTreeNodes(width, height, NUM) {
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const horizontal = width / NUM.ELEVEN;
-  return [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + horizontal, y: baseY * 22 },
-    { x: centerX - horizontal, y: baseY * 22 },
-    { x: centerX + horizontal * 1.4, y: baseY * 44 },
-    { x: centerX - horizontal * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + horizontal, y: baseY * 77 },
-    { x: centerX - horizontal, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-}
-
-// Layer 3: Fibonacci curve. Static golden spiral with gentle sampling.
-// Layer 3: Fibonacci curve. Static spiral honours the Golden Ratio without motion.
-function drawFibonacciCurve(ctx, width, height, color, NUM) {
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 3: Fibonacci curve — Golden Ratio spiral rendered once for calm focus.
-export function drawFibonacci(ctx, width, height, color, NUM) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-
-<<<<<<  // Golden Ratio constant keeps the spiral grounded in sacred proportion.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps sacred proportion stable.
-  const centerX = width / NUM.THREE * 2;
-  const centerY = height / NUM.THREE;
-  const scale = Math.min(width, height) / NUM.NINETYNINE;
-  const maxTheta = Math.PI * NUM.SEVEN;
-  const thetaStep = Math.PI / NUM.THIRTYTHREE;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= maxTheta; theta += thetaStep) {
-<<<<<<    const radius = scale * Math.pow(golden, theta / (Math.PI / 2));
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio constant keeps the growth soothing.
-  const center = {
-    x: (width / NUM.THREE) * 2,
-    y: height / NUM.THREE
-  };
-  const turns = NUM.THREE;
-  const scale = (Math.min(width, height) / NUM.NINETYNINE) * NUM.SEVEN;
-  const step = Math.PI / NUM.TWENTYTWO;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= Math.PI * 2 * turns; theta += step) {
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
-  ctx.stroke();
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = nodeColor;
+  ctx.strokeStyle = ink;
+  ctx.lineWidth = Math.max(1, Math.min(width, height) / NUM.ONEFORTYFOUR);
+
+  const nodeRadius = Math.max(4, Math.min(width, height) / NUM.TWENTYTWO);
+  for (const node of nodes) {
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
 
   ctx.restore();
 }
 
-<<<<<<// Layer 4: Double-helix lattice. Static strands avoid motion triggers.
-// Layer 4: Double-helix lattice with calm strands and steady crossbars.
-function drawHelixLattice(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 4: Double-helix lattice — static strands with crossbars, zero motion.
-export function drawHelix(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
+// Layer 3: Fibonacci curve. Static golden spiral sampled with gentle spacing.
+function drawFibonacciCurve(ctx, width, height, color, NUM) {
+  const centerX = width * 0.66;
+  const centerY = height * 0.62;
+  const baseRadius = Math.min(width, height) / NUM.THREE;
+  const phi = (1 + Math.sqrt(5)) / 2; // Golden Ratio constant (phi)
+  const growth = Math.log(phi) / (Math.PI / 2);
+  const turns = NUM.THREE; // three turns keep the curve legible and calm.
+  const steps = NUM.NINETYNINE;
+  const maxTheta = turns * Math.PI * 2;
+  const step = maxTheta / steps;
+
   ctx.save();
-
-  const steps = NUM.TWENTYTWO;
-  const amplitude = height / NUM.THIRTYTHREE;
-  const frequency = (Math.PI * NUM.ELEVEN) / width;
-  const baseline = height * 0.65;
-
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, 0, strandColorA);
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, Math.PI, strandColorB || strandColorA);
->>>>>>>+codex/add-codeb
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor);
-
-  ctx.restore();
-}
-
-function drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, phase, color) {
   ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
+  ctx.globalAlpha = 0.75;
+  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / NUM.ONEFORTYFOUR);
   ctx.beginPath();
+
   for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y = baseline + amplitude * Math.sin(frequency * x + phase);
+    const theta = i * step;
+    const radius = baseRadius * Math.exp(growth * theta);
+    const x = centerX + radius * Math.cos(theta);
+    const y = centerY - radius * Math.sin(theta);
     if (i === 0) {
       ctx.moveTo(x, y);
     } else {
       ctx.lineTo(x, y);
     }
   }
+
   ctx.stroke();
-}
-
-function drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, color) {
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y2 = baseline + amplitude * Math.sin(frequency * x + Math.PI);
-    // Static crossbars maintain the double-helix lattice without introducing motion.
->>>>>>>+codex/add-codeb
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const yA = baseline + amplitude * Math.sin(frequency * x);
-    const yB = baseline + amplitude * Math.sin(frequency * x + Math.PI);
-    ctx.beginPath();
-    ctx.moveTo(x, yA);
-    ctx.lineTo(x, yB);
-    ctx.stroke();
-  }
-}
-  fillBackground(ctx, width, height, palette.bg);
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, NUM);
-}
-
-function ensurePalette(palette) {
-  if (!palette) return DEFAULT_PALETTE;
-  const layers = Array.isArray(palette.layers) ? palette.layers.slice(0, 6) : [];
-  if (layers.length < 6) return DEFAULT_PALETTE;
-  return {
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(input) {
-  return { ...DEFAULT_NUM, ...(input || {}) };
-}
-
-function fillBackground(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
   ctx.restore();
 }
 
-// Layer 1: Vesica field — repeating circles for layered depth with no motion.
-export function drawVesica(ctx, width, height, color, NUM) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
-
-  const radius = Math.min(width, height) / NUM.NINE;
-  const offset = radius / NUM.THREE;
-<<  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let row = -Math.floor(rows / 2); row <= Math.floor(rows / 2); row++) {
-    for (let col = -Math.floor(columns / 2); col <= Math.floor(columns / 2); col++) {
-      const cx = width / 2 + col * horizontalStep;
-      const cy = height / 2 + row * verticalStep;
-
-      ctx.beginPath();
-      ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
-
-      ctx.beginPath();
-      ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-      ctx.stroke();
->>>>>>>+codex/add-codeb
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const horizontalStep = radius;
-  const verticalStep = radius * (NUM.SEVEN / NUM.NINE);
-  const columns = NUM.SEVEN;
-  const rows = NUM.NINE;
-
-  for (let r = -Math.floor(rows / 2); r <= Math.floor(rows / 2); r++) {
-    for (let c = -Math.floor(columns / 2); c <= Math.floor(columns / 2); c++) {
-      const cx = width / 2 + c * horizontalStep;
-      const cy = height / 2 + r * verticalStep;
-      drawCirclePair(ctx, cx, cy, radius, offset);
-    }
-  }
-
-  ctx.restore();
-}
-
-<<// Layer 2: Tree-of-Life scaffold. Symmetric layout, no flashing.
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, NUM) {
-  const nodes = createTreeNodes(width, height, NUM);
-  const paths = createTreePaths();
-
-// Layer 2: Tree-of-Life scaffold with ten sephirot and twenty-two connective paths.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, NUM) {
->>>>>>>+codex/add-codeb
-=====
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-function drawCirclePair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-// Layer 2: Tree-of-Life scaffold — static nodes and calm paths.
-export function drawTree(ctx, width, height, edgeColor, nodeColor, NUM) {
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 2;
-  paths.forEach(([a, b]) => {
-
-<<<<  const columnSpacing = width / NUM.THIRTYTHREE;
-  const rowSpacing = (height / NUM.NINETYNINE) * NUM.NINE;
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const spread = width / NUM.ELEVEN;
-
-  const nodes = [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + spread, y: baseY * 22 },
-    { x: centerX - spread, y: baseY * 22 },
-    { x: centerX + spread * 1.4, y: baseY * 44 },
-    { x: centerX - spread * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + spread, y: baseY * 77 },
-    { x: centerX - spread, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-
-  const paths = [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-
->>>>>>> main
-  paths.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a].x, nodes[a].y);
-    ctx.lineTo(nodes[b].x, nodes[b].y);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-<<<<  const nodeRadius = Math.max(3, width / NUM.NINETYNINE);
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const radius = Math.max(3, width / NUM.NINETYNINE);
-  nodes.forEach(node => {
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-  });
-
-  ctx.restore();
-}
-
-<<<<<<< codex/update-registry-for-numbers-0-144
-// Layer 3: Fibonacci curve. Static golden spiral expresses growth without motion.
-<<<<function createTreeNodes(width, height, NUM) {
-  const baseY = height / NUM.ONEFORTYFOUR;
-  const centerX = width / 2;
-  const horizontal = width / NUM.ELEVEN;
-  return [
-    { x: centerX, y: baseY * 9 },
-    { x: centerX + horizontal, y: baseY * 22 },
-    { x: centerX - horizontal, y: baseY * 22 },
-    { x: centerX + horizontal * 1.4, y: baseY * 44 },
-    { x: centerX - horizontal * 1.4, y: baseY * 44 },
-    { x: centerX, y: baseY * 55 },
-    { x: centerX + horizontal, y: baseY * 77 },
-    { x: centerX - horizontal, y: baseY * 77 },
-    { x: centerX, y: baseY * 99 },
-    { x: centerX, y: baseY * 126 }
-  ];
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [6, 9], [7, 9], [8, 9],
-    [2, 3], [1, 4]
-  ];
-}
-
-// Layer 3: Fibonacci curve. Static golden spiral with gentle sampling.
-// Layer 3: Fibonacci curve. Static spiral honours the Golden Ratio without motion.
-function drawFibonacciCurve(ctx, width, height, color, NUM) {
->>>>>>>+codex/add-codeb
-===
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 3: Fibonacci curve — Golden Ratio spiral rendered once for calm focus.
-export function drawFibonacci(ctx, width, height, color, NUM) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-
-  // Golden Ratio ensures the spiral honours lineage growth while remaining static.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
-  const baseScale = Math.min(width, height) / NUM.NINETYNINE * NUM.SEVEN;
-<<<<<<  // Golden Ratio constant keeps the spiral grounded in sacred proportion.
-  const golden = (1 + Math.sqrt(5)) / 2;
-  const center = { x: (width / NUM.THREE) * 2, y: height / NUM.THREE };
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio keeps sacred proportion stable.
-  const centerX = width / NUM.THREE * 2;
-  const centerY = height / NUM.THREE;
-  const scale = Math.min(width, height) / NUM.NINETYNINE;
->>>>>>> main
-  const maxTheta = Math.PI * NUM.SEVEN;
-  const thetaStep = Math.PI / NUM.THIRTYTHREE;
-
-  ctx.beginPath();
-  for (let theta = 0; theta <= maxTheta; theta += thetaStep) {
-    const radius = baseScale * Math.pow(golden, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-<<<<<<    const radius = scale * Math.pow(golden, theta / (Math.PI / 2));
-  const goldenRatio = (1 + Math.sqrt(5)) / 2; // Golden Ratio constant keeps the growth soothing.
-  const center = {
-    x: (width / NUM.THREE) * 2,
-    y: height / NUM.THREE
-  };
+// Layer 4: Double-helix lattice. Two phase-shifted strands with calm crossbars.
+function drawHelixLattice(ctx, width, height, strandAColor, strandBColor, rungColor, NUM) {
+  const steps = NUM.ONEFORTYFOUR;
   const turns = NUM.THREE;
-  const scale = (Math.min(width, height) / NUM.NINETYNINE) * NUM.SEVEN;
-  const step = Math.PI / NUM.TWENTYTWO;
+  const centerX = width / 2;
+  const amplitude = width / NUM.ELEVEN;
+  const yStep = height / steps;
 
-  ctx.beginPath();
-  for (let theta = 0; theta <= Math.PI * 2 * turns; theta += step) {
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = center.x + radius * Math.cos(theta);
-    const y = center.y + radius * Math.sin(theta);
-    if (theta === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const radius = scale * Math.pow(goldenRatio, theta / (Math.PI / 2));
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    if (theta === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
->>>>>>> main
-  }
-  ctx.stroke();
+  const strands = [
+    { phase: 0, color: strandAColor, points: [] },
+    { phase: Math.PI, color: strandBColor, points: [] }
+  ];
 
-  ctx.restore();
-}
-
-// Layer 4: Double-helix lattice. Static strands echo DNA symbolism without animation.
-<<<<<<// Layer 4: Double-helix lattice. Static strands avoid motion triggers.
-// Layer 4: Double-helix lattice with calm strands and steady crossbars.
-function drawHelixLattice(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
->>>>>>>+codex/add-codeb
-=
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-// Layer 4: Double-helix lattice — static strands with crossbars, zero motion.
-export function drawHelix(ctx, width, height, strandColorA, strandColorB, rungColor, NUM) {
-  ctx.save();
-
-  const steps = NUM.TWENTYTWO;
-  const amplitude = height / NUM.THIRTYTHREE;
-  const frequency = (Math.PI * NUM.ELEVEN) / width;
-  const baseline = height * 0.65;
-
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, 0, strandColorA);
-  drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, Math.PI, strandColorB || strandColorA);
-<<<<<<<   drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor || strandColorA);
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
->>>>>>> main
-  drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, rungColor);
-
-  ctx.restore();
-}
-
-function drawHelixStrand(ctx, width, steps, amplitude, frequency, baseline, phase, color) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y = baseline + amplitude * Math.sin(frequency * x + phase);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-  ctx.restore();
-}
-
-function drawHelixRungs(ctx, width, steps, amplitude, frequency, baseline, color) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= steps; i++) {
-    const x = (width / steps) * i;
-    const y2 = baseline + amplitude * Math.sin(frequency * x + Math.PI);
-<<<<<<< codex/update-registry-for-numbers-0-144
-    // Static crossbars maintain the double-helix lattice without introducing motion.
->>>>>>> origin/codex/architect-one-complete-laboratory-node-e6l88d
-    const yA = baseline + amplitude * Math.sin(frequency * x);
-    const yB = baseline + amplitude * Math.sin(frequency * x + Math.PI);
->>>>>>> main
+  for (const strand of strands) {
+    ctx.save();
+    ctx.strokeStyle = strand.color;
+    ctx.globalAlpha = 0.85;
+    ctx.lineWidth = Math.max(1.5, Math.min(width, height) / NUM.NINETYNINE);
     ctx.beginPath();
-    ctx.moveTo(x, yA);
-    ctx.lineTo(x, yB);
+
+    for (let i = 0; i <= steps; i++) {
+      const theta = (i / steps) * (Math.PI * 2 * turns) + strand.phase;
+      const y = i * yStep;
+      const x = centerX + Math.sin(theta) * amplitude;
+      strand.points.push({ x, y });
+      if (i === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Crossbars: evenly spaced rungs tie the strands together without motion.
+  ctx.save();
+  ctx.strokeStyle = rungColor;
+  ctx.globalAlpha = 0.55;
+  ctx.lineWidth = Math.max(1, Math.min(width, height) / NUM.ONEFORTYFOUR);
+
+  const rungCount = NUM.TWENTYTWO;
+  const stride = Math.floor(steps / (rungCount + 1));
+  for (let i = stride; i < strands[0].points.length && i < strands[1].points.length; i += stride) {
+    const a = strands[0].points[i];
+    const b = strands[1].points[i];
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
+
   ctx.restore();
 }


### PR DESCRIPTION
## Summary
- rewrite the offline index shell with palette fallback messaging and numerology constants
- rebuild the helix renderer module with pure helpers for vesica, tree-of-life, fibonacci, and helix lattice layers
- refresh the renderer README to document ND-safe usage, files, and numerology-driven design

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce54b3998483289e290342b0dc0716