### PR TITLE
Refine offline helix renderer shell

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -4,62 +4,33 @@ Static offline HTML5 canvas renderer for the layered cosmology in Codex 144:99. 
 
 ## Files
 - `index.html` - Entry document with the 1440x900 canvas, palette loader, and header status notice.
-- `js/helix-renderer.mjs` - ES module exporting `renderHelix` with pure helpers for each geometric layer.
+- `js/helix-renderer.mjs` - ES module exporting `renderHelix` plus pure helpers for each geometric layer.
 - `data/palette.json` - Optional ND-safe palette override (background, ink, and six layer hues).
 - `README_RENDERER.md` - This usage and safety guide.
 
-## Layered Output
-1. **Vesica field** (Layer 1) - Nine-by-seven vesica grid anchors the scene and grounds the depth perception.
-2. **Tree-of-Life scaffold** (Layer 2) - Ten sephirot nodes and twenty-two major arcana paths plotted with numerology spacing.
-3. **Fibonacci curve** (Layer 3) - Static golden spiral sampled once with gentle markers for growth waypoints.
-4. **Double-helix lattice** (Layer 4) - Two phase-shifted strands with steady crossbars to preserve layered geometry.
+## Layer Stack
+1. **Vesica field** (Layer 1) - Nine-by-seven grid of intersecting circles anchors the space with vesica overlaps.
+2. **Tree-of-Life scaffold** (Layer 2) - Ten sephirot nodes and twenty-two connective paths drawn with numerology spacing.
+3. **Fibonacci curve** (Layer 3) - Static golden spiral polyline sampled gently for calm focus.
+4. **Double-helix lattice** (Layer 4) - Two phase-shifted strands with steady crossbars for depth, never implying motion.
 
 ## Numerology Anchors
-Geometry parameters derive from sacred constants: 3, 7, 9, 11, 22, 33, 99, and 144. These values set grid counts, sampling density, spacing units, and strand turns so symbolism stays traceable and lore-safe.
-
-## Palette and Fallback
-- On load the page tries to read `data/palette.json` via `fetch`. If the browser blocks local file access, the renderer reports a gentle inline notice and uses the built-in ND-safe palette.
-- Adjust `palette.json` to suit your lighting conditions (six calm layer colors are expected). Keep contrast near WCAG AA for trauma-informed clarity.
-
-## ND-safe Design
-- No animation, flashing, or autoplay; the canvas renders once on load to avoid sensory overload.
-- Calm contrast with readable typography and generous spacing is maintained in both the HTML shell and the canvas layers.
-- Lore from the cosmology dataset is preserved in the module so node/path names and numerology remain intact for future rituals.
-- Pure functions and clear comments explain how each layer is derived, keeping adaptations reversible.
-
-## Offline Use
-1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
-2. Optionally update `data/palette.json` before opening the page.
-3. Double-click `index.html`. Chromium, Firefox, and WebKit builds render the scene offline without extra tooling.
-4. If palette loading fails because of local file sandboxing, the fallback palette renders automatically and the header reports the safe mode.
-
-This renderer stays intentionally lightweight: no workflows, no dependencies, and no background services. Geometry is calculated by small pure functions so the layered cosmology remains legible and trauma-informed.
-- `index.html` &mdash; entry document with a 1440&times;900 canvas, palette loader, and inline status notice.
-- `js/helix-renderer.mjs` &mdash; ES module exporting `renderHelix` plus pure helpers for each geometric layer.
-- `data/palette.json` &mdash; optional ND-safe palette override (background, ink, and six layer hues).
-- `README_RENDERER.md` &mdash; this usage and safety guide.
-
-## Layer Stack
-1. **Vesica field** (Layer&nbsp;1) &mdash; nine-by-seven grid of intersecting circles anchors the space with vesica overlaps.
-2. **Tree-of-Life scaffold** (Layer&nbsp;2) &mdash; ten sephirot nodes and twenty-two connective paths drawn with numerology spacing.
-3. **Fibonacci curve** (Layer&nbsp;3) &mdash; static golden spiral polyline sampled gently for calm focus.
-4. **Double-helix lattice** (Layer&nbsp;4) &mdash; two phase-shifted strands with steady crossbars for depth, never implying motion.
-
-## Geometry and Numerology
-The renderer relies on the sacred constants 3, 7, 9, 11, 22, 33, 99, and 144 to size and position geometry:
-- Vesica grid counts nine columns by seven rows; circle radii derive from `3 / (9 - 7)` to keep gentle overlap.
-- Tree-of-Life spacing uses `144` units as the vertical baseline, six intervals (`3 + 3`) to form seven levels, and offsets scaled by `7/11`, `9/22`, and `1/3` factors of the canvas width.
-- The Fibonacci spiral samples `99` points over a `33/22` turn sweep to echo golden growth while staying static.
-- The double helix traces three twists with amplitude `width / 7`, phase shift `π / (9 - 7)`, and eleven rungs to honor the arcana paths.
+Geometry parameters derive from the sacred constants 3, 7, 9, 11, 22, 33, 99, and 144. These values set grid counts, sampling density, spacing units, and strand turns so symbolism stays traceable and lore-safe.
 
 ## Palette and Fallback
 - On load the page attempts to fetch `data/palette.json`. When the file is missing or the browser blocks file fetches, a calm fallback palette renders automatically and the header reports the safe mode.
-- Colors maintain high contrast between background, ink, and layer hues to remain ND-safe. Comments in the module explain each choice so future changes stay trauma-informed.
+- Adjust `palette.json` to suit your lighting conditions (six calm layer colors are expected). Keep contrast near WCAG AA for trauma-informed clarity.
+
+## ND-safe Design Choices
+- No animation, flashing, or autoplay; the canvas renders once on load to avoid sensory overload.
+- Calm contrast with readable typography and generous spacing is maintained in both the HTML shell and the canvas layers.
+- Lore from the cosmology dataset is preserved in the module so node/path names and numerology remain intact for future rituals.
+- Pure functions and clear comments explain how each layer is derived, keeping adaptations reversible and offline-friendly.
 
 ## Offline Use
 1. Keep the repository folders intact so relative imports resolve (`js/` and `data/`).
 2. Optionally adjust `data/palette.json` before opening the page; provide background, ink, and six layer colors.
 3. Double-click `index.html`. Chromium, Firefox, and WebKit render the canvas offline with no additional tooling.
-4. If palette loading fails in file:// contexts, the fallback palette draws immediately and the status note acknowledges the mode.
+4. If palette loading fails in file:// contexts, the fallback palette draws immediately and the status note acknowledges the safe mode.
 
-No animation, flashing, or workflows are introduced. Each layer renders once via small pure functions to keep the cosmology legible, ND-safe, and ready for future expansions.
+This renderer stays intentionally lightweight: no workflows, no dependencies, and no background services. Geometry is calculated by small pure functions so the layered cosmology remains legible and trauma-informed.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe styling: calm contrast, no motion, generous spacing for sensory ease. */
-    /* ND-safe styling: calm contrast, generous spacing, and no motion */
     :root {
       --bg: #0b0b12;
       --ink: #e8e8f0;
@@ -50,12 +49,11 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Preparing palette&hellip;</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, and no external libraries. Open this file directly.</p>
-  <p class="note">Static renderer expressing the Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
+  <p class="note">Static Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice &mdash; one calm render, no animation, no external libraries.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -64,22 +62,25 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas ? canvas.getContext("2d") : null;
 
+    // Helper keeps status updates safe when the element is absent.
+    function setStatus(text) {
+      if (statusEl) {
+        statusEl.textContent = text;
+      }
+    }
+
     async function loadJSON(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response || !response.ok) return null;
         return await response.json();
       } catch (error) {
-        /* Offline-first ND safety: browsers often block file:// fetch. Returning null uses the fallback palette. */
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res || !res.ok) return null;
-        return await res.json();
-      } catch (error) {
-        // Offline-first ND safety: browsers may block file:// fetch calls, so fall back quietly.
+        /* Offline-first ND safety: browsers may block file:// fetch; return null so the fallback activates quietly. */
         return null;
       }
     }
 
+    // Calm fallback palette keeps the scene readable when palette.json is missing or blocked.
     const FALLBACK = {
       palette: {
         bg: "#0b0b12",
@@ -90,7 +91,13 @@
 
     const paletteData = await loadJSON("./data/palette.json");
     const activePalette = paletteData ?? FALLBACK.palette;
-    const statusPrefix = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const statusMessage = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    const rootStyle = document.documentElement.style;
+    // ND-safe shell: sync CSS custom properties with the active palette for consistent contrast.
+    rootStyle.setProperty("--bg", activePalette.bg);
+    rootStyle.setProperty("--ink", activePalette.ink);
+    rootStyle.setProperty("--muted", "#a6a6c1");
 
     // Numerology constants keep geometry aligned with the requested cosmology.
     const NUM = Object.freeze({
@@ -104,27 +111,11 @@
       ONEFORTYFOUR: 144
     });
 
-    // ND-safe rationale: one synchronous render, calm tones, layered depth preserved.
     if (!ctx) {
-      statusEl.textContent = `${statusPrefix} Canvas context unavailable; rendering skipped.`;
-      return;
-    }
-
-    statusEl.textContent = statusPrefix;
-    const targetWidth = canvas ? canvas.width : 1440;
-    const targetHeight = canvas ? canvas.height : 900;
-    renderHelix(ctx, { width: targetWidth, height: targetHeight, palette: activePalette, NUM });
-    async function init() {
-      if (!ctx) {
-        statusEl.textContent = "Canvas unavailable; nothing rendered.";
-        return;
-      }
-
-      const palette = await loadJSON("./data/palette.json");
-      const activePalette = palette ? palette : FALLBACK.palette;
-      statusEl.textContent = palette ? "Palette loaded." : "Palette missing or blocked; using safe fallback.";
-
-      // ND-safe rationale: render once with calm colors and clear layer order.
+      setStatus(`${statusMessage} Canvas context unavailable; rendering skipped.`);
+    } else {
+      setStatus(statusMessage);
+      // ND-safe rationale: one synchronous render with calm tones and clear layer order.
       renderHelix(ctx, {
         width: canvas.width,
         height: canvas.height,
@@ -132,8 +123,6 @@
         NUM
       });
     }
-
-    init();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline the offline HTML shell so the palette loader falls back safely and updates the ND-safe CSS variables
- add inline comments explaining the ND-safe rationale and simplify duplicate text
- trim and reorganize README_RENDERER to document the four-layer stack and offline usage succinctly

## Testing
- not run (static renderer)


------
https://chatgpt.com/codex/tasks/task_e_68d032f470108328827cc37c8dafa025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Clearer loading status with dynamic updates.
  * Richer default palette with layered rendering when palette.json is unavailable, plus safe-mode messaging.
  * Consistent contrast by syncing theme colors with the active palette.
  * Single calm, non-animated render optimized for offline, library-free use.

* Documentation
  * Renamed/reframed sections (e.g., “Layer Stack,” “ND-safe Design Choices”) and refined wording.
  * Clarified palette fallback behavior and offline usage instructions.
  * Updated language to be more trauma-informed and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->