### PR TITLE
Refine helix renderer layering and docs

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,35 +1,35 @@
 # Cosmic Helix Renderer
 
-Static offline HTML5 canvas renderer for the layered cosmology encoded in Codex 144:99. Double-click `index.html` to render the vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice once-no workflows, no dependencies, and no background services.
+Static offline HTML5 canvas renderer for the layered cosmology encoded in Codex 144:99. Double-click `index.html` to render the vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice once: no workflows, no dependencies, and no background services.
 
 ## Files
-- `index.html` - ND-safe shell with the 1440x900 canvas, palette loader, and status notice.
-- `js/helix-renderer.mjs` - ES module exporting `renderHelix` plus pure helpers for each sacred layer.
-- `data/palette.json` - Optional ND-safe palette override (background, ink, and six layer hues).
-- `dist/codex.min.json` - Minified data export consumed by other repos (nodes 0..10 ship first).
-- `README_RENDERER.md` - This usage and safety guide.
+- `index.html` &mdash; ND-safe shell with the 1440x900 canvas, palette loader, and status notice.
+- `js/helix-renderer.mjs` &mdash; ES module exporting `renderHelix` plus pure helpers for each sacred layer.
+- `data/palette.json` &mdash; Optional ND-safe palette override (background, ink, and six layer hues).
+- `dist/codex.min.json` &mdash; Minified data export consumed by sibling codex viewers.
+- `README_RENDERER.md` &mdash; This usage and safety guide.
 
 ## Layer Stack
-1. **Vesica field** - Intersecting circles form a nine-by-seven vesica lattice that grounds the canvas.
-2. **Tree-of-Life scaffold** - Ten sephirot nodes and twenty-two connective paths maintain Kabbalistic structure.
-3. **Fibonacci curve** - Static golden spiral polyline sampled once with gentle marker stones.
-4. **Double-helix lattice** - Two phase-shifted strands with twenty-two calm crossbars suggest layered depth.
+1. **Vesica field** &mdash; Intersecting circles form a nine-by-seven vesica lattice that grounds the canvas.
+2. **Tree-of-Life scaffold** &mdash; Ten sephirot nodes and twenty-two connective paths maintain Kabbalistic structure.
+3. **Fibonacci curve** &mdash; Static golden spiral polyline sampled once with gentle marker stones.
+4. **Double-helix lattice** &mdash; Two phase-shifted strands with twenty-two calm crossbars suggest layered depth.
 
 ## Numerology Anchors
 Geometry settings honor the sacred constants 3, 7, 9, 11, 22, 33, 99, and 144. These values drive circle counts, path totals, spiral sampling density, helix frequency, and lattice spacing so numerological intent stays legible.
 
 ## Palette and Fallback
-The renderer attempts to read `data/palette.json`. When browsers block local `file://` fetches, the calm fallback palette-background, ink, and six layer colors-activates automatically. Keep hues near WCAG AA contrast for trauma-informed clarity; update the JSON before opening `index.html` to tailor lighting.
+The renderer attempts to read `data/palette.json`. When browsers block local `file://` fetches, the calm fallback palette (background, ink, and six layer colors) activates automatically. Keep hues near WCAG AA contrast for trauma-informed clarity; update the JSON before opening `index.html` to tailor lighting.
 
 ## ND-safe Design Choices
 - No animation, flashing, or autoplay; the canvas renders once on load.
 - Calm contrast, generous whitespace, and layer comments document sensory intent.
 - Pure functions keep geometry math auditable and reversible for caretakers.
-- Trauma-informed pacing: optional helix sweep data still enforces a 14 s minimum when motion requires consent.
+- Trauma-informed pacing: any optional motion work elsewhere in the codex keeps a 14 s minimum sweep to respect consent.
 
 ## Offline Use
-1. Keep `index.html`, `js/`, `data/`, and `dist/` together so relative imports resolve.
-2. Optionally edit `data/palette.json` or node metadata before viewing.
+1. Keep `index.html`, `js/`, and `data/` together so relative imports resolve.
+2. Optionally edit `data/palette.json` before viewing.
 3. Double-click `index.html`. Chromium, Firefox, and WebKit all render offline without servers.
 4. If palette loading fails in `file://` contexts, the header status reports the safe fallback; rendering still completes once.
 

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
       padding: 0;
       background: var(--bg);
       color: var(--ink);
-      font: 15px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     }
 
     header {
-      padding: 12px 18px;
+      padding: 12px 16px;
       border-bottom: 1px solid #1d1d2a;
       background: #101021;
       color: var(--ink);
@@ -45,9 +45,9 @@
     }
 
     .note {
-      max-width: 960px;
-      margin: 0 auto 20px;
-      padding: 0 18px 18px;
+      max-width: 900px;
+      margin: 0 auto 16px;
+      padding: 0 16px 16px;
       color: var(--muted);
     }
 
@@ -65,21 +65,23 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry for quiet focus.</div>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note"><strong>Static Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice</strong> - rendered once in a trauma-informed palette with no animation, no autoplay, and no external dependencies. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and double-helix layers once with a trauma-informed palette. No animation, no autoplay, and no external libraries.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const statusEl = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas ? canvas.getContext("2d") : null;
 
-    function setStatus(text) {
+    function setStatus(message) {
       if (statusEl) {
-        statusEl.textContent = text;
+        statusEl.textContent = message;
       }
     }
 
@@ -91,7 +93,7 @@
         }
         return await response.json();
       } catch (error) {
-        // Offline-first ND safety: browsers may block file:// fetch; return null so the fallback activates quietly.
+        // Offline-first ND safety: browsers may block file:// fetch; return null so the fallback activates calmly.
         return null;
       }
     }
@@ -104,18 +106,16 @@
       }
     });
 
-    const paletteData = await loadJSON("./data/palette.json");
-    const activePalette = paletteData ?? FALLBACK.palette;
-    const statusMessage = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const palette = await loadJSON("./data/palette.json");
+    const activePalette = palette || FALLBACK.palette;
+    const statusMessage = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
     setStatus(statusMessage);
 
+    // Update CSS variables so the surrounding page mirrors the chosen palette for readability.
     const rootStyle = document.documentElement.style;
     rootStyle.setProperty("--bg", activePalette.bg);
     rootStyle.setProperty("--ink", activePalette.ink);
     rootStyle.setProperty("--muted", "#a6a6c1");
-
-    const canvas = document.getElementById("stage");
-    const ctx = canvas ? canvas.getContext("2d") : null;
 
     const NUM = Object.freeze({
       THREE: 3,
@@ -128,11 +128,10 @@
       ONEFORTYFOUR: 144
     });
 
-    // ND-safe shell: render once, no motion, all numerology constants explicit for audit.
     if (!ctx) {
       setStatus("Canvas unavailable; rendering skipped.");
     } else {
-      // ND-safe rationale: renderHelix paints four calm layers without timers or animation hooks.
+      // Render once with four calm layers; no timers keep motion absent.
       renderHelix(ctx, {
         width: canvas.width,
         height: canvas.height,

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -108,14 +108,16 @@ function drawVesica(ctx, width, height, palette, NUM) {
 
   const columns = NUM.NINE;
   const rows = NUM.SEVEN;
-  const radius = Math.min(width / (columns + 2), height / (rows + 2)) * 0.75;
-  const offsetX = (width - (columns - 1) * radius) / 2;
-  const offsetY = (height - (rows - 1) * radius) / 2;
+  const radius = Math.min(width / (columns + 2), height / (rows + 2)) * 0.9;
+  const spacingX = radius * (NUM.SEVEN / NUM.NINE); // 7/9 keeps lenses interlocked.
+  const spacingY = radius * (NUM.THREE / NUM.SEVEN); // 3/7 keeps vertical cadence gentle.
+  const startX = (width - (columns - 1) * spacingX) / 2;
+  const startY = (height - (rows - 1) * spacingY) / 2;
 
   for (let row = 0; row < rows; row += 1) {
     for (let col = 0; col < columns; col += 1) {
-      const cx = offsetX + col * radius;
-      const cy = offsetY + row * radius;
+      const cx = startX + col * spacingX;
+      const cy = startY + row * spacingY;
       ctx.beginPath();
       ctx.arc(cx, cy, radius, 0, Math.PI * 2);
       ctx.stroke();
@@ -151,7 +153,8 @@ const TREE_PATHS = [
 function mapTreePositions(width, height, NUM) {
   const verticalSpan = height * 0.72;
   const top = height * 0.12;
-  const levelStep = verticalSpan / (NUM.ONEFORTYFOUR / NUM.TWENTYTWO);
+  const levels = NUM.SEVEN; // Seven vertical steps echo Tree-of-Life pillars.
+  const levelStep = verticalSpan / (levels - 1);
   const horizontalUnit = width / (NUM.THREE * NUM.SEVEN);
   const centerX = width / 2;
 
@@ -170,6 +173,8 @@ function drawTree(ctx, width, height, palette, NUM) {
 
   ctx.strokeStyle = palette.layers[1];
   ctx.lineWidth = 1.5;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
   ctx.globalAlpha = 0.8;
   for (const [fromKey, toKey] of TREE_PATHS) {
     const from = positions.get(fromKey);
@@ -221,6 +226,7 @@ function drawFibonacci(ctx, width, height, palette, NUM) {
 
   ctx.strokeStyle = palette.layers[3];
   ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
   ctx.globalAlpha = 0.85;
   ctx.beginPath();
   ctx.moveTo(points[0].x, points[0].y);
@@ -254,10 +260,11 @@ function drawHelix(ctx, width, height, palette, NUM) {
   const verticalMargin = height * 0.12;
   const usableHeight = height - verticalMargin * 2;
   const amplitude = width / NUM.ELEVEN;
-  const frequency = NUM.THREE + NUM.SEVEN / NUM.TWENTYTWO;
+  const frequency = NUM.THREE + NUM.SEVEN / NUM.TWENTYTWO; // 3 + 7/22 keeps the twist gentle.
   const samples = NUM.ONEFORTYFOUR;
 
   ctx.lineWidth = 1.5;
+  ctx.lineCap = 'round';
   ctx.globalAlpha = 0.9;
 
   function drawStrand(color, phase) {
@@ -278,13 +285,13 @@ function drawHelix(ctx, width, height, palette, NUM) {
   drawStrand(palette.layers[5], 0);
   drawStrand(palette.layers[4], Math.PI);
 
-  // Crossbars tie the two strands without implying motion; 33 anchors yield 22 calm rungs.
-  const rungCount = NUM.THIRTYTHREE - NUM.ELEVEN;
+  // Crossbars tie the two strands without implying motion; twenty-two rungs honor the path count.
+  const rungCount = NUM.TWENTYTWO;
   ctx.strokeStyle = palette.ink;
   ctx.globalAlpha = 0.6;
-  const rungStep = Math.max(1, rungCount - 1);
+  const rungSpacing = rungCount > 1 ? 1 / (rungCount - 1) : 0;
   for (let i = 0; i < rungCount; i += 1) {
-    const t = i / rungStep;
+    const t = i * rungSpacing;
     const a = helixPoint(t, 0, width, verticalMargin, usableHeight, amplitude, frequency);
     const b = helixPoint(t, Math.PI, width, verticalMargin, usableHeight, amplitude, frequency);
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- polish the offline index shell with updated copy, palette fallback handling, and numerology constants
- refine vesica spacing, tree layout, Fibonacci stroke styling, and helix rung counts in the renderer module
- refresh the renderer readme with file listings, ND-safe guidance, and data export notes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2e3f3f6ac8328ba84b124457b00a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Data Export guidance for regenerating and validating codex data (including motion opt-in constraint).
- Style
  - Refined typography, spacing, and header copy; simplified note text.
  - Smoother visuals with rounded line caps/joins for trees, Fibonacci, and helix strands.
  - Evenly spaced helix crossbars; updated vesica sizing/spacing and a clearer seven-level tree layout.
- Refactor
  - Centralized canvas/context init; single non-timed render flow.
  - More resilient palette loading with document-wide CSS variable sync.
- Documentation
  - Reworded and reorganized README for clarity and offline workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->